### PR TITLE
style: 사이드바 메뉴/탐색 간격 분리 및 텍스트 시인성 강화

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -209,8 +209,8 @@ export const Sidebar = () => {
 
       {/* Main Navigation — 워크스페이스 스코프 메뉴 */}
       <div className="flex-1 px-2 space-y-0.5 overflow-y-auto">
-        <div className="mb-2 px-2 pt-2">
-          <div className="text-[11px] font-bold text-slate-500 mb-1 px-2 uppercase tracking-wider">메뉴</div>
+        <div className="mb-6 px-2 pt-4">
+          <div className="text-xs font-bold text-slate-400 mb-2 px-2 tracking-wide">메뉴</div>
           {menuItems.map((item) => (
             <button
               key={item.subpath}
@@ -229,8 +229,8 @@ export const Sidebar = () => {
         </div>
 
         {/* 탐색 섹션 (글로벌) */}
-        <div className="mb-2 px-2">
-          <div className="text-[11px] font-bold text-slate-500 mb-1 px-2 uppercase tracking-wider">탐색</div>
+        <div className="mb-4 px-2 pt-6 border-t border-slate-800/50 mt-4">
+          <div className="text-xs font-bold text-slate-400 mb-2 px-2 tracking-wide">탐색</div>
           <button
             onClick={() => navigate('/explore')}
             className={cn(


### PR DESCRIPTION
## ��� 사이드바 UI 개선

### ��� 목적 및 배경
- 기존 사이드바의 '메뉴'와 '탐색' 영역이 너무 가까이 붙어있어 역할 구분이 모호하다는 이슈를 해결했습니다.
- 카테고리를 나타내는 텍스트 라벨들이 너무 작아 한눈에 직관적으로 들어오지 않는 문제를 개선했습니다.

### ✨ 주요 변경 사항

#### 1. 카테고리 텍스트 시인성 향상
- '메뉴'와 '탐색'을 나타내는 최상위 카테고리 텍스트를 `text-[11px]`에서 `text-xs (12px)` 사이즈로 상향 조정했습니다.
- `tracking-wide`(자간 넓힘) 속성을 부여해 텍스트의 선명도를 한 차원 끌어올렸습니다.

#### 2. 레이아웃 분리 및 여백 조정
- '메뉴' 섹션과 '탐색' 섹션 사이에 확연한 여백(간격)을 추가하여 두 영역의 역할을 시각적으로 완벽하게 분리했습니다.
- '탐색' 영역 윗부분에 `border-t border-slate-800/50` 연한 구분선을 삽입해 안정감을 더했습니다.