### PR TITLE
feat: 커뮤니티 탭 통합, 태그 필터/검색 및 작성 페이지 추가 (Step 4)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { ProblemList } from './features/problems/ProblemList';
 import { Profile } from './features/user/Profile';
 import { Settings } from './features/user/Settings';
 import { Community } from './features/community/Community';
+import { PostCreate } from './features/community/PostCreate';
 import { Login } from './features/auth/Login';
 import { SignUp } from './features/auth/SignUp';
 import { OAuthCallback } from './features/auth/OAuthCallback';
@@ -64,7 +65,7 @@ function WorkspaceScope({ children }: { children: React.ReactNode }) {
       try {
         const res = await getWorkspaces();
         if (cancelled) return;
-        const items = (res.items ?? []).map(w => ({
+        const items = (res.items ?? []).map((w: any) => ({
           id: w.id!,
           name: w.name!,
           description: w.description ?? null,
@@ -202,6 +203,9 @@ function AppContent() {
           } />
           <Route path="/ws/:wsId/community" element={
             <ProtectedRoute><WorkspaceScope><Community /></WorkspaceScope></ProtectedRoute>
+          } />
+          <Route path="/ws/:wsId/community/new" element={
+            <ProtectedRoute><WorkspaceScope><PostCreate /></WorkspaceScope></ProtectedRoute>
           } />
           <Route path="/ws/:wsId/challenges" element={
             <ProtectedRoute><WorkspaceScope><ChallengeList /></WorkspaceScope></ProtectedRoute>

--- a/src/features/community/Community.tsx
+++ b/src/features/community/Community.tsx
@@ -1,145 +1,172 @@
 import React, { useState } from 'react';
-import { useRecoilState } from 'recoil';
-import { communityTabState } from '@/store/atoms';
+import { useWorkspaceNavigate } from '@/hooks/useWorkspaceNavigate';
 import { Button, Badge } from '@/components/ui/Base';
 import {
+  PenSquare,
   MessageCircle,
   Megaphone,
-  PenSquare,
-  Eye
+  Eye,
+  Filter,
+  Check,
+  Search
 } from 'lucide-react';
 
-// Sub-component: Free Board
-const FreeBoard = () => {
-  const posts = [
-    { id: 1, title: "이번 주 챌린지 같이 하실 분?", author: "CodeWarrior", date: "2024.02.10", likes: 5, comments: 2 },
-    { id: 2, title: "BFS랑 DFS 중에 뭐가 더 어렵나요?", author: "Newbie", date: "2024.02.09", likes: 12, comments: 8 },
-    { id: 3, title: "취업 준비하면서 알고리즘 공부 팁 공유합니다", author: "DevMaster", date: "2024.02.08", likes: 45, comments: 15 },
-    { id: 4, title: "파이썬 시간초과 해결 방법 좀...", author: "PyLover", date: "2024.02.08", likes: 2, comments: 4 },
-  ];
+type TagType = '전체' | '공지' | '자유' | '질문' | '꿀팁';
+
+interface Post {
+  id: number;
+  title: string;
+  author: string;
+  date: string;
+  likes: number;
+  comments: number;
+  views: number;
+  tag: TagType;
+  isNotice: boolean;
+}
+
+const MOCK_POSTS: Post[] = [
+  { id: 6, title: "시스템 점검 안내 (02/10 02:00 ~ 04:00)", author: "관리자", date: "2024.02.08", likes: 10, comments: 0, views: 1250, tag: "공지", isNotice: true },
+  { id: 5, title: "새로운 챌린지 시즌 5가 시작됩니다!", author: "관리자", date: "2024.02.05", likes: 45, comments: 12, views: 3400, tag: "공지", isNotice: true },
+  { id: 4, title: "이번 주 챌린지 같이 하실 분?", author: "CodeWarrior", date: "2024.02.10", likes: 5, comments: 2, views: 42, tag: "자유", isNotice: false },
+  { id: 3, title: "BFS랑 DFS 중에 뭐가 더 어렵나요?", author: "Newbie", date: "2024.02.09", likes: 12, comments: 8, views: 150, tag: "질문", isNotice: false },
+  { id: 2, title: "취업 준비하면서 알고리즘 공부 팁 공유합니다", author: "DevMaster", date: "2024.02.08", likes: 45, comments: 15, views: 500, tag: "꿀팁", isNotice: false },
+  { id: 1, title: "파이썬 시간초과 해결 방법 좀...", author: "PyLover", date: "2024.02.08", likes: 2, comments: 4, views: 30, tag: "질문", isNotice: false },
+];
+
+export const Community = () => {
+  const { toWs } = useWorkspaceNavigate();
+  const [selectedTag, setSelectedTag] = useState<TagType>('전체');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Tag Filter Options
+  const filterTags: TagType[] = ['전체', '자유', '질문', '꿀팁'];
+
+  // Filtering Logic
+  let notices = MOCK_POSTS.filter(p => p.isNotice);
+  let normalPosts = MOCK_POSTS.filter(p => !p.isNotice);
+
+  if (selectedTag !== '전체') {
+    normalPosts = normalPosts.filter(p => p.tag === selectedTag);
+  }
+
+  if (searchQuery.trim() !== '') {
+    const q = searchQuery.toLowerCase();
+    notices = notices.filter(p => p.title.toLowerCase().includes(q));
+    normalPosts = normalPosts.filter(p => p.title.toLowerCase().includes(q));
+  }
+
+  const getTagBadge = (tag: TagType, isNotice: boolean) => {
+    if (isNotice) return <Badge variant="destructive" className="bg-red-500/10 text-red-500 border-red-500/20 w-12 justify-center">공지</Badge>;
+    if (tag === '자유') return <Badge variant="outline" className="border-blue-500/30 text-blue-400 bg-blue-500/10 w-12 justify-center">자유</Badge>;
+    if (tag === '질문') return <Badge variant="outline" className="border-orange-500/30 text-orange-400 bg-orange-500/10 w-12 justify-center">질문</Badge>;
+    if (tag === '꿀팁') return <Badge variant="outline" className="border-emerald-500/30 text-emerald-400 bg-emerald-500/10 w-12 justify-center">꿀팁</Badge>;
+    return null;
+  };
 
   return (
-    <div className="flex-1 p-8 overflow-y-auto bg-[#0F1117]">
+    <div className="flex-1 p-8 overflow-y-auto bg-[#0F1117] h-full">
       <div className="max-w-7xl mx-auto space-y-6">
-        <div className="flex justify-between items-center">
+        {/* Header */}
+        <div className="flex justify-between items-center border-b border-slate-800 pb-6">
           <div>
-            <h2 className="text-xl font-bold text-slate-100">자유 게시판</h2>
-            <p className="text-slate-400 text-sm mt-1">자유롭게 이야기를 나누어 보세요.</p>
+            <h1 className="text-3xl font-extrabold text-white tracking-tight mb-2">커뮤니티</h1>
+            <p className="text-slate-400 text-sm">팀원들과 자유롭게 이야기를 나누고 지식을 공유하세요.</p>
           </div>
-          <Button className="bg-emerald-600 hover:bg-emerald-700 gap-2" onClick={() => alert('글쓰기 기능은 준비 중입니다.')}>
-            <PenSquare className="w-4 h-4" /> 글쓰기
+          <Button className="bg-emerald-600 hover:bg-emerald-700 gap-2 font-bold px-5" onClick={() => toWs('community/new')}>
+            <PenSquare className="w-4 h-4" /> 새 게시물 작성
           </Button>
         </div>
 
-        <div className="bg-slate-900/50 border border-slate-800 rounded-xl overflow-hidden">
-          <table className="w-full text-left border-collapse">
-            <thead>
-              <tr className="border-b border-slate-800 bg-[#141820] text-slate-400 text-sm">
-                <th className="p-4 font-medium w-16 text-center">#</th>
-                <th className="p-4 font-medium">제목</th>
-                <th className="p-4 font-medium w-32">작성자</th>
-                <th className="p-4 font-medium w-32 text-center">날짜</th>
-                <th className="p-4 font-medium w-20 text-center">추천</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-800/50">
-              {posts.map(post => (
-                <tr key={post.id} className="hover:bg-slate-800/30 transition-colors cursor-pointer group">
-                  <td className="p-4 text-center text-slate-500 text-sm">{post.id}</td>
-                  <td className="p-4 text-slate-200 group-hover:text-emerald-400 transition-colors">
-                    {post.title}
-                    {post.comments > 0 && (
-                      <span className="ml-2 text-xs text-slate-500 font-mono">[{post.comments}]</span>
-                    )}
-                  </td>
-                  <td className="p-4 text-slate-400 text-sm">{post.author}</td>
-                  <td className="p-4 text-center text-slate-500 text-xs">{post.date}</td>
-                  <td className="p-4 text-center text-emerald-500 text-sm font-medium">{post.likes}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-  );
-};
+        {/* Filters and Search */}
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 py-2">
+          {/* Tags */}
+          <div className="flex items-center gap-3">
+            <Filter className="w-4 h-4 text-slate-500" />
+            <span className="text-sm font-medium text-slate-400 mr-2">태그 필터:</span>
+            {filterTags.map(tag => (
+              <button
+                key={tag}
+                onClick={() => setSelectedTag(tag)}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-bold transition-all border ${selectedTag === tag
+                  ? 'bg-emerald-500/20 text-emerald-400 border-emerald-500/50 shadow-sm'
+                  : 'bg-slate-800/50 text-slate-400 border-transparent hover:bg-slate-700 hover:text-slate-200'
+                  }`}
+              >
+                {selectedTag === tag && <Check className="w-3 h-3" />}
+                {tag}
+              </button>
+            ))}
+          </div>
 
-// Sub-component: Notice Board
-const NoticeBoard = () => {
-  const notices = [
-    { id: 1, title: "시스템 점검 안내 (02/10 02:00 ~ 04:00)", date: "2024.02.08", views: 1250 },
-    { id: 2, title: "새로운 챌린지 시즌 5가 시작됩니다!", date: "2024.02.05", views: 3400 },
-    { id: 3, title: "IDE 다크 모드 가독성 개선 업데이트", date: "2024.02.01", views: 890 },
-  ];
-
-  return (
-    <div className="flex-1 p-8 overflow-y-auto bg-[#0F1117]">
-      <div className="max-w-7xl mx-auto space-y-6">
-        <div className="flex justify-between items-center">
-          <div>
-            <h2 className="text-xl font-bold text-slate-100">공지사항</h2>
-            <p className="text-slate-400 text-sm mt-1">새로운 소식과 업데이트를 확인하세요.</p>
+          {/* Search Input */}
+          <div className="relative w-full sm:w-64">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+            <input
+              type="text"
+              placeholder="게시물 제목 검색..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full bg-slate-900 border border-slate-700 rounded-lg py-1.5 pl-9 pr-4 text-sm text-slate-200 focus:outline-none focus:border-emerald-500 transition-colors placeholder:text-slate-500"
+            />
           </div>
         </div>
 
-        <div className="space-y-4">
-          {notices.map(notice => (
-            <div
-              key={notice.id}
-              className="p-6 bg-slate-900/50 border border-slate-800 rounded-xl hover:border-emerald-500/50 hover:bg-slate-800/50 transition-all cursor-pointer"
-            >
-              <div className="flex items-center gap-2 mb-2">
-                <Badge variant="destructive" className="bg-red-500/10 text-red-500 border-red-500/20">공지</Badge>
-                <span className="text-slate-500 text-xs">{notice.date}</span>
-              </div>
-              <h3 className="text-lg font-bold text-slate-200 mb-2">{notice.title}</h3>
-              <div className="flex items-center gap-4 text-xs text-slate-500">
-                <span className="flex items-center gap-1"><Eye className="w-3 h-3" /> {notice.views}</span>
-                <span>작성자: 관리자</span>
-              </div>
-            </div>
-          ))}
+        {/* Board Table */}
+        <div className="bg-[#141820] border border-slate-800 rounded-xl overflow-hidden shadow-sm">
+          <table className="w-full text-left border-collapse">
+            <thead>
+              <tr className="border-b border-slate-800 bg-[#151922] text-slate-400 text-xs uppercase tracking-wider">
+                <th className="p-4 font-bold w-20 text-center">분류</th>
+                <th className="p-4 font-bold">제목</th>
+                <th className="p-4 font-bold w-32">작성자</th>
+                <th className="p-4 font-bold w-32 text-center">작성일</th>
+                <th className="p-4 font-bold w-20 text-center">조회</th>
+                <th className="p-4 font-bold w-20 text-center">추천</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800/50 text-sm">
+              {/* 공지사항 (항상 상단 픽스) */}
+              {notices.map(post => (
+                <tr key={`notice-${post.id}`} className="bg-red-500/5 hover:bg-red-500/10 transition-colors cursor-pointer group">
+                  <td className="p-4 text-center">{getTagBadge(post.tag, post.isNotice)}</td>
+                  <td className="p-4 text-slate-100 font-medium group-hover:text-red-400 transition-colors">
+                    {post.title}
+                    {post.comments > 0 && <span className="ml-2 text-xs text-red-500/70 font-mono">[{post.comments}]</span>}
+                  </td>
+                  <td className="p-4 text-slate-400">{post.author}</td>
+                  <td className="p-4 text-center text-slate-500 font-mono text-xs">{post.date}</td>
+                  <td className="p-4 text-center text-slate-500 font-mono">{post.views}</td>
+                  <td className="p-4 text-center text-emerald-500 font-bold font-mono">{post.likes}</td>
+                </tr>
+              ))}
+
+              {/* 일반 포스트 (필터링 적용) */}
+              {normalPosts.map(post => (
+                <tr key={`post-${post.id}`} className="hover:bg-slate-800/50 transition-colors cursor-pointer group">
+                  <td className="p-4 text-center">{getTagBadge(post.tag, post.isNotice)}</td>
+                  <td className="p-4 text-slate-200 group-hover:text-emerald-400 transition-colors">
+                    {post.title}
+                    {post.comments > 0 && <span className="ml-2 text-xs text-emerald-500/70 font-mono">[{post.comments}]</span>}
+                  </td>
+                  <td className="p-4 text-slate-400">{post.author}</td>
+                  <td className="p-4 text-center text-slate-500 font-mono text-xs">{post.date}</td>
+                  <td className="p-4 text-center text-slate-500 font-mono">{post.views}</td>
+                  <td className="p-4 text-center text-emerald-500 font-bold font-mono">{post.likes}</td>
+                </tr>
+              ))}
+
+              {normalPosts.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="p-12 text-center text-slate-500">
+                    <MessageCircle className="w-8 h-8 mx-auto mb-3 opacity-20" />
+                    해당 태그의 게시글이 없습니다.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
         </div>
-      </div>
-    </div>
-  );
-};
-
-// Main Community Container
-export const Community = () => {
-  const [activeTab, setActiveTab] = useRecoilState(communityTabState);
-
-  const tabs = [
-    { id: 'notices', label: '공지사항', icon: Megaphone },
-    { id: 'free', label: '자유 게시판', icon: MessageCircle },
-  ];
-
-  return (
-    <div className="flex flex-col h-full bg-[#0F1117]">
-      {/* Top Navigation Tabs */}
-      <div className="h-14 border-b border-slate-800 flex items-center px-4 bg-[#0F1117]">
-        <div className="flex space-x-1 bg-slate-900/50 p-1 rounded-lg border border-slate-800">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`flex items-center gap-2 px-4 py-1.5 rounded-md text-sm font-medium transition-all ${activeTab === tab.id
-                  ? 'bg-emerald-600 text-white shadow-sm'
-                  : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800'
-                }`}
-            >
-              <tab.icon className="w-4 h-4" />
-              {tab.label}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Content Area */}
-      <div className="flex-1 flex overflow-hidden">
-        {activeTab === 'notices' && <NoticeBoard />}
-        {activeTab === 'free' && <FreeBoard />}
       </div>
     </div>
   );

--- a/src/features/community/PostCreate.tsx
+++ b/src/features/community/PostCreate.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import { Card, Button } from '@/components/ui/Base';
+import { useWorkspaceNavigate } from '@/hooks/useWorkspaceNavigate';
+import {
+    PenSquare,
+    ArrowLeft,
+    Check
+} from 'lucide-react';
+
+export const PostCreate = () => {
+    const { toWs } = useWorkspaceNavigate();
+    const [title, setTitle] = useState('');
+    const [content, setContent] = useState('');
+    const [selectedTag, setSelectedTag] = useState<string>('자유');
+
+    const availableTags = ['자유', '질문', '꿀팁', '공지'];
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!title.trim() || !content.trim()) {
+            alert('제목과 내용을 모두 입력해주세요.');
+            return;
+        }
+        // TODO: 백엔드 연동 영역 (현재는 임시)
+        console.log('--- 새 게시물 작성 ---');
+        console.log({
+            title,
+            content,
+            tag: selectedTag,
+        });
+        alert('게시글이 성공적으로 작성되었습니다!');
+        toWs('community');
+    };
+
+    return (
+        <div className="flex-1 p-8 overflow-y-auto bg-[#0F1117] h-full">
+            <div className="max-w-4xl mx-auto space-y-6">
+
+                {/* Header */}
+                <div className="flex items-center gap-4 border-b border-slate-800 pb-6">
+                    <button
+                        onClick={() => toWs('community')}
+                        className="p-2 text-slate-400 hover:text-slate-200 hover:bg-slate-800 rounded-full transition-colors focus:outline-none"
+                    >
+                        <ArrowLeft className="w-5 h-5" />
+                    </button>
+                    <div>
+                        <h1 className="text-2xl font-extrabold text-white tracking-tight">새 게시물 작성</h1>
+                        <p className="text-slate-400 text-sm mt-1">팀원들에게 유용한 정보를 공유하거나 질문해보세요.</p>
+                    </div>
+                </div>
+
+                {/* Editor Form */}
+                <Card className="bg-[#141820] border-slate-800 p-6 shadow-sm">
+                    <form onSubmit={handleSubmit} className="space-y-6">
+
+                        {/* Tag Selection */}
+                        <div>
+                            <label className="block text-sm font-bold text-slate-300 mb-3">태그 분류</label>
+                            <div className="flex gap-2">
+                                {availableTags.map(tag => (
+                                    <button
+                                        key={tag}
+                                        type="button"
+                                        onClick={() => setSelectedTag(tag)}
+                                        className={`flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-bold transition-all border ${selectedTag === tag
+                                            ? 'bg-emerald-500/20 text-emerald-400 border-emerald-500/50 shadow-sm'
+                                            : 'bg-slate-900 text-slate-400 border-slate-800 hover:bg-slate-800 hover:text-slate-200'
+                                            }`}
+                                    >
+                                        {selectedTag === tag && <Check className="w-3.5 h-3.5" />}
+                                        {tag}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+
+                        {/* Title Input */}
+                        <div>
+                            <input
+                                type="text"
+                                value={title}
+                                onChange={(e) => setTitle(e.target.value)}
+                                placeholder="게시물 제목을 입력하세요"
+                                className="w-full bg-transparent border-0 border-b border-transparent focus:outline-none focus:ring-0 text-2xl font-bold text-slate-100 placeholder:text-slate-600 focus:border-b focus:border-emerald-500/50 transition-colors pb-2"
+                                autoFocus
+                            />
+                        </div>
+
+                        {/* Content Textarea */}
+                        <div>
+                            <textarea
+                                value={content}
+                                onChange={(e) => setContent(e.target.value)}
+                                placeholder="여기에 내용을 작성하세요..."
+                                className="w-full min-h-[400px] bg-slate-900/50 border border-slate-800 rounded-xl p-4 text-slate-200 text-sm placeholder:text-slate-600 focus:outline-none focus:border-emerald-500/50 focus:bg-slate-900 transition-colors resize-y leading-relaxed"
+                            />
+                        </div>
+
+                        {/* Action Buttons */}
+                        <div className="flex justify-end gap-3 pt-4 border-t border-slate-800">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => toWs('community')}
+                                className="border-slate-700 text-slate-300 hover:bg-slate-800 hover:text-white"
+                            >
+                                취소
+                            </Button>
+                            <Button
+                                type="submit"
+                                className="bg-emerald-600 hover:bg-emerald-700 font-bold px-6 gap-2"
+                            >
+                                <PenSquare className="w-4 h-4" /> 작성 완료
+                            </Button>
+                        </div>
+                    </form>
+                </Card>
+            </div>
+        </div>
+    );
+};

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -87,10 +87,6 @@ export const userState = atom({
   default: loadUser(),
 });
 
-export const communityTabState = atom({
-  key: 'communityTabState',
-  default: 'notices',
-});
 
 // 챌린지 타입
 export interface Challenge {


### PR DESCRIPTION
## 🚀 워크스페이스 커뮤니티 전면 개편

### 📊 목적 및 배경
- 분산되어 있던 '공지사항'과 '자유게시판' 탭을 제거하고 하나로 뷰를 통합했습니다.
- 태그(Tag) 개념을 도입해 사용자가 효율적으로 문서를 분류하고, 원하는 목적의 문서만 모아볼 수 있도록 UI/UX를 개선했습니다.

### ✨ 주요 변경 사항

#### 1. 커뮤니티 페이지 통합 및 UI 개선
- 탭 구조 제거 후 단일 테이블(List) 레이아웃으로 화면을 일원화했습니다.
- 게시글의 속성을 직관적으로 파악할 수 있도록 리스트 최좌측에 [분류] 카테고리 뱃지를 적용했습니다 (예: 공지, 자유, 질문, 꿀팁).

#### 2. 태그(Tag) 필터 기능 적용 & 공지 상단 고정
- 상단 영역에 필터 버튼 그룹을 배치해, 클릭만으로 특정 태그의 문서만 즉시 필터링 되도록 적용했습니다.
- **[공지] 태그를 가진 작성 문서는 항상 어떠한 필터링 규칙에도 무관하게 최상단에 고정** 되어 최우선적으로 노출되도록 배치했습니다.

#### 3. 게시물 검색 기능 추가
- 유저가 원하는 텍스트 기반으로 지난 글을 빠르게 찾을 수 있게 [제목 검색창]을 필터 우측에 추가했습니다.
- 일반 문서는 물론 상단 고정된 공지사항까지 포함하여, 대소문자 구분 없이 실시간으로 입력어 기반 필터링(검색)이 매끄럽게 동작하게 구성했습니다.

#### 4. '새 게시물 작성' 페이지 분리 신설
- [새 게시물 작성] 버튼을 클릭 시 별도의 새 라우트(`/ws/:wsId/community/new`)로 진입하도록 컴포넌트를 신설했습니다.
- 태그 지정, 큰 글씨체의 제목 입력, 노션 스타일의 대본창(Textarea)을 배치하여 플랫폼 고유의 일관된 UI 감각을 적용했습니다. (추후 실제 API 연동을 위한 뼈대를 튼튼히 구축해두었습니다.)
