### PR TITLE
feat: GET /api/v1/workspaces를 /workspaces/me로 마이그레이션

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
             "@radix-ui/react-tooltip": "^1.1.8",
             "@tailwindcss/postcss": "^4.1.18",
             "@tailwindcss/typography": "^0.5.19",
-            "@ujax/api-spec": "github:ujax-v2/ujax-api-spec#f1aae44",
+            "@ujax/api-spec": "github:ujax-v2/ujax-api-spec#4fb5f14",
             "class-variance-authority": "^0.7.1",
             "clsx": "*",
             "cmdk": "^1.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,9 +67,9 @@ function WorkspaceScope({ children }: { children: React.ReactNode }) {
       try {
         const res = await getWorkspaces();
         if (cancelled) return;
-        const items = (res.items ?? []).map((w: any) => ({
-          id: w.id!,
-          name: w.name!,
+        const items = (res.content ?? []).map((w) => ({
+          id: w.id,
+          name: w.name,
           description: w.description ?? null,
         })) as Workspace[];
         setWorkspaces(items);

--- a/src/api/workspace.ts
+++ b/src/api/workspace.ts
@@ -4,8 +4,8 @@ import { authFetch } from './client';
 type ApiWorkspace = components['schemas']['ApiResponse-WorkspaceResponse'];
 export type WorkspaceResponse = ApiWorkspace['data'];
 
-type ApiWorkspaceList = components['schemas']['ApiResponse-WorkspaceList'];
-export type WorkspaceListResponse = ApiWorkspaceList['data'];
+type ApiWorkspaceMyPage = components['schemas']['ApiResponse-WorkspaceMyPage'];
+export type WorkspaceMyPageResponse = ApiWorkspaceMyPage['data'];
 
 type ApiWorkspaceSettings = components['schemas']['ApiResponse-WorkspaceSettings'];
 export type WorkspaceSettingsResponse = ApiWorkspaceSettings['data'];
@@ -24,8 +24,8 @@ export type PageResponseWorkspaceResponse = ApiWorkspaceExplore['data'];
 
 // ──── 워크스페이스 CRUD ────
 
-export async function getWorkspaces(): Promise<WorkspaceListResponse> {
-  const res = await authFetch('/api/v1/workspaces');
+export async function getWorkspaces(page = 0, size = 100): Promise<WorkspaceMyPageResponse> {
+  const res = await authFetch(`/api/v1/workspaces/me?page=${page}&size=${size}`);
   return res.data;
 }
 

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -54,9 +54,9 @@ export const Home = () => {
             try {
                 const res = await getWorkspaces();
                 if (cancelled) return;
-                const items = (res.items ?? []).map((w: any) => ({
-                    id: w.id!,
-                    name: w.name!,
+                const items = (res.content ?? []).map((w) => ({
+                    id: w.id,
+                    name: w.name,
                     description: w.description ?? null,
                 })) as Workspace[];
                 setWorkspaces(items);


### PR DESCRIPTION
- api-spec 4fb5f14로 업데이트 (WorkspaceMyPage 스키마 반영)
- getWorkspaces() 엔드포인트를 /workspaces/me로 변경
- 응답 필드 items → content로 변경 (페이징 응답 구조)
- any 타입 캐스팅 제거