### PR TITLE
fix: 유저 데이터 불일치 해소 (id 추가, getMe 호출, nickname→name)

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -62,7 +62,7 @@ export const Sidebar = () => {
       // logout API 실패해도 로컬 상태는 초기화
     }
     localStorage.removeItem('auth');
-    setUser({ isLoggedIn: false, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' });
+    setUser({ isLoggedIn: false, id: 0, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' });
     setWorkspaces([]);
     setCurrentWorkspaceId(0);
     navigate('/login');

--- a/src/features/auth/Login.tsx
+++ b/src/features/auth/Login.tsx
@@ -3,6 +3,7 @@ import { useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import { userState, workspacesState, currentWorkspaceState } from '@/store/atoms';
 import { loginApi } from '@/api/auth';
+import { getMe } from '@/api/user';
 import { Button, Card } from '@/components/ui/Base';
 import { Mail, Lock, MessageCircle } from 'lucide-react';
 
@@ -34,37 +35,27 @@ export const Login = ({ oauthError, onClearError }: LoginProps) => {
       const result = await loginApi(email, password);
       const { accessToken, refreshToken } = result.data;
 
-      // Decode JWT to get user info fallback
-      let name = email;
-      try {
-        const base64 = accessToken!.split('.')[1];
-        const binaryStr = atob(base64);
-        const bytes = new Uint8Array(binaryStr.length);
-        for (let i = 0; i < binaryStr.length; i++) {
-          bytes[i] = binaryStr.charCodeAt(i);
-        }
-        const payload = JSON.parse(new TextDecoder().decode(bytes));
-        name = payload.name || email;
-      } catch (e) {
-        // ignore jwt parse error if any
-      }
+      // 토큰을 먼저 저장 (getMe가 authFetch를 사용하므로)
+      localStorage.setItem('auth', JSON.stringify({ accessToken, refreshToken }));
+
+      // getMe()로 완전한 유저 정보 조회
+      const me = await getMe();
 
       const userData = {
         isLoggedIn: true,
-        name: name,
-        email: email,
-        avatar: '',
-        profileImageUrl: '',
-        baekjoonId: '',
-        provider: '',
+        id: me.id,
+        name: me.name,
+        email: me.email,
+        avatar: me.name,
+        profileImageUrl: me.profileImageUrl ?? '',
+        baekjoonId: me.baekjoonId ?? '',
+        provider: me.provider,
         accessToken: accessToken!,
         refreshToken: refreshToken!,
       };
 
-      // Save to local storage
       localStorage.setItem('auth', JSON.stringify(userData));
 
-      // 이전 세션 워크스페이스 초기화 후 유저 상태 설정
       setWorkspaces([]);
       setCurrentWsId(0);
       setUser(userData);

--- a/src/features/auth/OAuthCallback.tsx
+++ b/src/features/auth/OAuthCallback.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import { userState, workspacesState, currentWorkspaceState } from '@/store/atoms';
+import { getMe } from '@/api/user';
 
 interface Props {
   onComplete?: (error?: string) => void;
@@ -37,34 +38,38 @@ export const OAuthCallback = ({ onComplete }: Props) => {
     const accessToken = params.get('accessToken');
     const refreshToken = params.get('refreshToken');
     if (accessToken && refreshToken) {
-      try {
-        const binaryStr = atob(accessToken.split('.')[1]);
-        const bytes = new Uint8Array(binaryStr.length);
-        for (let i = 0; i < binaryStr.length; i++) bytes[i] = binaryStr.charCodeAt(i);
-        const payload = JSON.parse(new TextDecoder().decode(bytes));
-        const name = payload.name || '';
-        const email = payload.email || '';
-        const provider = payload.provider || ''; // Assuming provider is also in payload
-        localStorage.setItem('auth', JSON.stringify({ accessToken, refreshToken, name, email, provider })); // Added provider to localStorage
-        setWorkspaces([]);
-        setCurrentWsId(0);
-        setUser({
-          isLoggedIn: true,
-          name,
-          email,
-          avatar: name, // or payload.avatar if available
-          profileImageUrl: payload.profileImageUrl || '', // Assuming profileImageUrl is in payload
-          baekjoonId: payload.baekjoonId || '', // Assuming baekjoonId is in payload
-          provider,
-          accessToken,
-          refreshToken,
-        });
+      (async () => {
+        try {
+          // 토큰을 먼저 저장 (getMe가 authFetch를 사용하므로)
+          localStorage.setItem('auth', JSON.stringify({ accessToken, refreshToken }));
 
-        navigate('/', { replace: true });
-        if (onComplete) onComplete();
-      } catch {
-        navigate('/login', { replace: true });
-      }
+          // getMe()로 완전한 유저 정보 조회
+          const me = await getMe();
+
+          const userData = {
+            isLoggedIn: true,
+            id: me.id,
+            name: me.name,
+            email: me.email,
+            avatar: me.name,
+            profileImageUrl: me.profileImageUrl ?? '',
+            baekjoonId: me.baekjoonId ?? '',
+            provider: me.provider,
+            accessToken,
+            refreshToken,
+          };
+
+          localStorage.setItem('auth', JSON.stringify(userData));
+          setWorkspaces([]);
+          setCurrentWsId(0);
+          setUser(userData);
+
+          navigate('/', { replace: true });
+          if (onComplete) onComplete();
+        } catch {
+          navigate('/login', { replace: true });
+        }
+      })();
     } else {
       navigate('/login', { replace: true });
     }

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import { userState, workspacesState, currentWorkspaceState } from '@/store/atoms';
 import { signupApi } from '@/api/auth';
+import { getMe } from '@/api/user';
 import { Button, Card } from '@/components/ui/Base';
 import { Mail, Lock, User, AlertCircle, CheckCircle2 } from 'lucide-react';
 
@@ -51,34 +52,27 @@ export const SignUp = () => {
       const result = await signupApi(formData.email, formData.password, formData.nickname);
       const { accessToken, refreshToken } = result.data;
 
-      // Decode JWT to get user info fallback
-      let name = formData.nickname;
-      try {
-        const binaryStr = atob(accessToken!.split('.')[1]);
-        const bytes = new Uint8Array(binaryStr.length);
-        for (let i = 0; i < binaryStr.length; i++) bytes[i] = binaryStr.charCodeAt(i);
-        const payload = JSON.parse(new TextDecoder().decode(bytes));
-        name = payload.name || formData.nickname;
-      } catch (e) {
-        // ignore jwt parse error
-      }
+      // 토큰을 먼저 저장 (getMe가 authFetch를 사용하므로)
+      localStorage.setItem('auth', JSON.stringify({ accessToken, refreshToken }));
+
+      // getMe()로 완전한 유저 정보 조회
+      const me = await getMe();
 
       const userData = {
         isLoggedIn: true,
-        name,
-        email: formData.email, // Keeping original as userDto is not defined
-        avatar: '',
-        profileImageUrl: '', // Keeping original as userDto is not defined
-        baekjoonId: '',
-        provider: '', // Added based on instruction
+        id: me.id,
+        name: me.name,
+        email: me.email,
+        avatar: me.name,
+        profileImageUrl: me.profileImageUrl ?? '',
+        baekjoonId: me.baekjoonId ?? '',
+        provider: me.provider,
         accessToken: accessToken!,
         refreshToken: refreshToken!,
       };
 
-      // Save to local storage
       localStorage.setItem('auth', JSON.stringify(userData));
 
-      // 이전 세션 워크스페이스 초기화 후 유저 상태 설정
       setWorkspaces([]);
       setCurrentWsId(0);
       setUser(userData);

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -38,7 +38,7 @@ export const Home = () => {
             // logout API 실패해도 로컬 상태는 초기화
         }
         localStorage.removeItem('auth');
-        setUser({ isLoggedIn: false, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' });
+        setUser({ isLoggedIn: false, id: 0, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' });
         setWorkspaces([]);
         setProfileMenuOpen(false);
         navigate('/login');

--- a/src/features/user/Profile.tsx
+++ b/src/features/user/Profile.tsx
@@ -97,7 +97,7 @@ export const Profile = () => {
 
   // User Data from state (fallback for mockup metrics)
   const user = {
-    nickname: currentUser.name || '알려지지 않은 유저',
+    name: currentUser.name || '알려지지 않은 유저',
     email: currentUser.email || '이메일 정보 없음',
     reward: '0원',
     xp: 0,
@@ -163,7 +163,7 @@ export const Profile = () => {
             </div>
             <div className="grid grid-cols-[80px_1fr] gap-y-3 text-xs items-center">
               <div className="text-slate-500">닉네임</div>
-              <div className="text-slate-200 font-medium">{user.nickname}</div>
+              <div className="text-slate-200 font-medium">{user.name}</div>
 
               <div className="text-slate-500">이메일</div>
               <div className="text-slate-200 truncate pr-2">{user.email}</div>

--- a/src/features/user/settings/ProfileTab.tsx
+++ b/src/features/user/settings/ProfileTab.tsx
@@ -50,9 +50,12 @@ export const ProfileTab = () => {
       setUser(prev => {
         const next = {
           ...prev,
+          id: data.id,
           name: data.name,
+          email: data.email,
           profileImageUrl: data.profileImageUrl ?? '',
           baekjoonId: data.baekjoonId ?? '',
+          provider: data.provider,
         };
         try {
           const stored = localStorage.getItem('auth');
@@ -60,6 +63,7 @@ export const ProfileTab = () => {
             const parsed = JSON.parse(stored);
             localStorage.setItem('auth', JSON.stringify({
               ...parsed,
+              id: next.id,
               name: next.name,
               profileImageUrl: next.profileImageUrl,
               baekjoonId: next.baekjoonId,
@@ -188,7 +192,7 @@ export const ProfileTab = () => {
     try {
       await deleteMe();
       localStorage.removeItem('auth');
-      setUser({ isLoggedIn: false, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' });
+      setUser({ isLoggedIn: false, id: 0, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' });
       setWorkspaces([]);
       setCurrentWorkspaceId(0);
       navigate('/login');

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -61,6 +61,7 @@ export const ideIsExecutingState = atom({
 
 export interface UserState {
   isLoggedIn: boolean;
+  id: number;
   name: string;
   email: string;
   avatar: string;
@@ -79,6 +80,7 @@ function loadUser(): UserState {
       if (parsed && typeof parsed === 'object' && parsed.accessToken) {
         return {
           isLoggedIn: true,
+          id: parsed.id || 0,
           name: parsed.name || 'User',
           email: parsed.email || '',
           avatar: parsed.avatar || '',
@@ -94,7 +96,7 @@ function loadUser(): UserState {
     console.warn('Failed to load user session, clearing storage:', e);
     localStorage.removeItem('auth');
   }
-  return { isLoggedIn: false, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' };
+  return { isLoggedIn: false, id: 0, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' };
 }
 
 export const userState = atom<UserState>({


### PR DESCRIPTION
- UserState에 id 필드 추가 및 모든 초기화 지점 반영
- Login/SignUp/OAuthCallback에서 인증 후 getMe() 호출하여 완전한 유저 데이터(id, profileImageUrl, baekjoonId, provider) 확보
- Profile.tsx에서 nickname → name으로 필드명 통일
- ProfileTab에서 getMe() 결과에 id, provider 동기화 추가