### PR TITLE
feat: 라이트/다크 모드 테마 시스템 구현 및 워크스페이스 상태 유지

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,25 @@
 
   <!DOCTYPE html>
-  <html lang="ko">
+  <html lang="ko" class="dark">
     <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <title>UJAX - 알고리즘 공유 플랫폼</title>
+      <script>
+        // 페이지 로드 전 저장된 테마 적용 (깜빡임 방지)
+        (function() {
+          try {
+            var theme = JSON.parse(localStorage.getItem('theme'));
+            if (theme === 'light') {
+              document.documentElement.classList.remove('dark');
+            } else if (theme === 'system') {
+              if (!window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                document.documentElement.classList.remove('dark');
+              }
+            }
+          } catch(e) {}
+        })();
+      </script>
     </head>
 
     <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useRecoilState, useRecoilValue, RecoilRoot } from 'recoil';
 import { BrowserRouter, Routes, Route, Navigate, useLocation, useNavigate, useParams } from 'react-router-dom';
-import { sidebarOpenState, userState, currentWorkspaceState, workspacesState, Workspace } from './store/atoms';
+import { sidebarOpenState, userState, currentWorkspaceState, workspacesState, Workspace, themeState, ThemeMode } from './store/atoms';
 import { Sidebar } from './components/layout/Sidebar';
 import { getWorkspaces } from './api/workspace';
 import { Dashboard } from './features/dashboard/Dashboard';
@@ -61,6 +61,78 @@ const darkTheme = createTheme({
     },
   },
 });
+
+const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    background: { default: '#ffffff', paper: '#ffffff' },
+    primary: { main: '#6366f1' },
+  },
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: { backgroundImage: 'none', border: '1px solid #e2e8f0' },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          backgroundColor: '#f8fafc',
+          borderRadius: 8,
+          '& .MuiOutlinedInput-notchedOutline': { borderColor: '#e2e8f0' },
+          '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#cbd5e1' },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#6366f1' },
+        },
+        input: { color: '#0f172a' },
+      },
+    },
+    MuiInputLabel: {
+      styleOverrides: { root: { color: '#64748b' } },
+    },
+    MuiIconButton: {
+      styleOverrides: { root: { color: '#64748b' } },
+    },
+  },
+});
+
+/** Resolve effective theme: 'system' → check prefers-color-scheme */
+function useResolvedTheme(): 'light' | 'dark' {
+  const theme = useRecoilValue(themeState);
+  const [systemDark, setSystemDark] = React.useState(
+    () => window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
+
+  React.useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  if (theme === 'system') return systemDark ? 'dark' : 'light';
+  return theme;
+}
+
+/** Sync .dark class on <html> */
+function ThemeSync() {
+  const resolved = useResolvedTheme();
+
+  React.useEffect(() => {
+    const root = document.documentElement;
+    if (resolved === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [resolved]);
+
+  return null;
+}
+
+/** Expose resolved theme for MUI + components that need it */
+export function useIsDark(): boolean {
+  return useResolvedTheme() === 'dark';
+}
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const user = useRecoilValue(userState);
@@ -130,31 +202,31 @@ function WorkspaceScope({ children }: { children: React.ReactNode }) {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-screen bg-[#0F1117]">
-        <div className="w-8 h-8 border-2 border-slate-700 border-t-emerald-500 rounded-full animate-spin" />
+      <div className="flex items-center justify-center h-screen bg-page">
+        <div className="w-8 h-8 border-2 border-border-default border-t-emerald-500 rounded-full animate-spin" />
       </div>
     );
   }
 
   if (!isMember) {
     return (
-      <div className="flex flex-col items-center justify-center h-screen bg-[#0F1117] text-white p-4">
-        <div className="max-w-md text-center space-y-6 p-8 bg-[#141820] border border-slate-800 rounded-2xl shadow-2xl">
+      <div className="flex flex-col items-center justify-center h-screen bg-page text-text-primary p-4">
+        <div className="max-w-md text-center space-y-6 p-8 bg-surface border border-border-default rounded-2xl shadow-2xl">
           <div className="w-16 h-16 bg-red-500/10 rounded-full flex items-center justify-center mx-auto mb-2">
             <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-red-500">
               <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
               <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
             </svg>
           </div>
-          <h1 className="text-2xl font-bold text-slate-100">접근 권한이 없습니다</h1>
-          <p className="text-slate-400">
+          <h1 className="text-2xl font-bold text-text-primary">접근 권한이 없습니다</h1>
+          <p className="text-text-muted">
             요청하신 워크스페이스에 접근할 수 없습니다.<br />
             멤버가 아니거나 존재하지 않는 워크스페이스일 수 있습니다.
           </p>
           <div className="flex gap-3 justify-center pt-2">
             <button
               onClick={() => navigate('/')}
-              className="px-5 py-2.5 bg-slate-800 hover:bg-slate-700 text-slate-200 rounded-lg transition-colors font-medium text-sm"
+              className="px-5 py-2.5 bg-surface-subtle hover:bg-border-subtle text-text-secondary rounded-lg transition-colors font-medium text-sm"
             >
               홈으로
             </button>
@@ -200,13 +272,13 @@ function AppContent() {
 
   // 사이드바를 숨겨야 하는 페이지: 인증, IDE, 홈, 풀이 보기(solutions)
   const isFullScreen = ['/login', '/signup', '/auth/callback', '/'].includes(location.pathname)
-    || location.pathname.startsWith('/ide')
+    || location.pathname.includes('/ide')
     || location.pathname.includes('/solutions');
   // 워크스페이스가 없으면 사이드바 숨김 (컨텍스트 없으므로)
   const showSidebar = !isFullScreen && user.isLoggedIn && workspaces.length > 0;
 
   return (
-    <div className="flex h-screen bg-[#0F1117] text-white font-sans overflow-hidden selection:bg-emerald-500/30">
+    <div className="flex h-screen bg-page text-text-primary font-sans overflow-hidden selection:bg-emerald-500/30">
       {showSidebar && <Sidebar />}
       <div className="flex-1 flex flex-col min-w-0 relative">
         {/* Mobile / Collapsed Sidebar Trigger */}
@@ -214,7 +286,7 @@ function AppContent() {
           <div className="absolute top-3 left-3 z-50">
             <button
               onClick={() => setSidebarOpen(true)}
-              className="p-2 text-slate-400 hover:text-slate-100 hover:bg-slate-800 rounded-lg transition-colors"
+              className="p-2 text-text-muted hover:text-text-primary hover:bg-hover-bg rounded-lg transition-colors"
             >
               <Menu className="w-5 h-5" />
             </button>
@@ -259,9 +331,14 @@ function AppContent() {
             <ProtectedRoute><WorkspaceScope><ChallengeDetail /></WorkspaceScope></ProtectedRoute>
           } />
 
+          <Route path="/ws/:wsId/ide" element={
+            <ProtectedRoute><WorkspaceScope><IDE /></WorkspaceScope></ProtectedRoute>
+          } />
+          <Route path="/ws/:wsId/ide/:problemId" element={
+            <ProtectedRoute><WorkspaceScope><IDE /></WorkspaceScope></ProtectedRoute>
+          } />
+
           {/* ═══ 글로벌 라우트 (WS 무관) ═══ */}
-          <Route path="/ide" element={<ProtectedRoute><IDE /></ProtectedRoute>} />
-          <Route path="/ide/:problemId" element={<ProtectedRoute><IDE /></ProtectedRoute>} />
           <Route path="/problems/:id/solutions" element={<ProtectedRoute><ProblemSolutions /></ProtectedRoute>} />
 
           <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
@@ -282,17 +359,23 @@ function AppContent() {
   );
 }
 
+function MuiThemeWrapper({ children }: { children: React.ReactNode }) {
+  const isDark = useIsDark();
+  return <ThemeProvider theme={isDark ? darkTheme : lightTheme}>{children}</ThemeProvider>;
+}
+
 export default function App() {
   return (
     <RecoilRoot>
-      <ThemeProvider theme={darkTheme}>
+      <MuiThemeWrapper>
         <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="ko">
           <BrowserRouter>
+            <ThemeSync />
             <AppContent />
             <CreateWorkspaceModal />
           </BrowserRouter>
         </LocalizationProvider>
-      </ThemeProvider>
+      </MuiThemeWrapper>
     </RecoilRoot>
   );
 }

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -43,22 +43,22 @@ class ErrorBoundary extends Component<Props, State> {
             if (this.props.fallback) return this.props.fallback;
 
             return (
-                <div className="flex flex-col items-center justify-center min-h-screen bg-[#0F1117] text-white p-4">
-                    <div className="max-w-md w-full bg-[#141820] border border-slate-800 rounded-xl p-8 shadow-2xl text-center space-y-6">
+                <div className="flex flex-col items-center justify-center min-h-screen bg-page text-text-primary p-4">
+                    <div className="max-w-md w-full bg-surface border border-border-default rounded-xl p-8 shadow-2xl text-center space-y-6">
                         <div className="w-16 h-16 bg-red-500/10 rounded-full flex items-center justify-center mx-auto">
                             <span className="text-3xl">⚠️</span>
                         </div>
 
                         <div>
-                            <h2 className="text-xl font-bold text-slate-100 mb-2">예기치 못한 오류가 발생했습니다</h2>
-                            <p className="text-sm text-slate-400">
+                            <h2 className="text-xl font-bold text-text-primary mb-2">예기치 못한 오류가 발생했습니다</h2>
+                            <p className="text-sm text-text-muted">
                                 죄송합니다. 요청을 처리하는 중에 문제가 발생했습니다.<br />
                                 지속적으로 발생할 경우 캐시를 삭제해 보세요.
                             </p>
                         </div>
 
                         {process.env.NODE_ENV === 'development' && this.state.error && (
-                            <div className="text-left bg-black/50 p-4 rounded text-xs font-mono text-red-300 overflow-auto max-h-32">
+                            <div className="text-left bg-black/50 p-4 rounded text-xs font-mono text-red-600 dark:text-red-300 overflow-auto max-h-32">
                                 {this.state.error.toString()}
                             </div>
                         )}
@@ -73,7 +73,7 @@ class ErrorBoundary extends Component<Props, State> {
 
                             <button
                                 onClick={this.handleReset}
-                                className="w-full py-3 bg-slate-800 hover:bg-slate-700 text-slate-300 font-medium rounded-lg transition-colors text-sm"
+                                className="w-full py-3 bg-surface-subtle hover:bg-border-subtle text-text-secondary font-medium rounded-lg transition-colors text-sm"
                             >
                                 초기화 후 메인으로 (로그아웃)
                             </button>

--- a/src/components/figma/ImageWithFallback.tsx
+++ b/src/components/figma/ImageWithFallback.tsx
@@ -14,7 +14,7 @@ export function ImageWithFallback(props: React.ImgHTMLAttributes<HTMLImageElemen
 
   return didError ? (
     <div
-      className={`inline-block bg-gray-100 text-center align-middle ${className ?? ''}`}
+      className={`inline-block bg-surface-subtle text-center align-middle ${className ?? ''}`}
       style={style}
     >
       <div className="flex items-center justify-center w-full h-full">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -64,7 +64,6 @@ export const Sidebar = () => {
     localStorage.removeItem('auth');
     setUser({ isLoggedIn: false, id: 0, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' });
     setWorkspaces([]);
-    setCurrentWorkspaceId(0);
     navigate('/login');
   };
 
@@ -105,26 +104,26 @@ export const Sidebar = () => {
   if (!isOpen) return null;
 
   return (
-    <div className="w-64 h-full bg-[#0a0c10] border-r border-slate-800 flex flex-col flex-shrink-0 transition-all duration-300 relative z-50">
+    <div className="w-64 h-full bg-[#f0f1f4] dark:bg-[#0a0c10] border-r border-border-subtle/50 shadow-[1px_0_4px_rgba(0,0,0,0.03)] dark:shadow-[1px_0_4px_rgba(0,0,0,0.2)] flex flex-col flex-shrink-0 transition-all duration-300 relative z-50">
       {/* Header with Workspace Switcher */}
       <div className="p-3 relative" ref={menuRef}>
         <div
           onClick={() => setIsWorkspaceMenuOpen(!isWorkspaceMenuOpen)}
-          className="h-10 flex items-center justify-between px-2 hover:bg-slate-800/50 transition-colors cursor-pointer rounded-lg group select-none"
+          className="h-10 flex items-center justify-between px-2 hover:bg-hover-bg transition-colors cursor-pointer rounded-lg group select-none"
         >
           <div className="flex items-center gap-2 overflow-hidden">
             <div className="w-5 h-5 rounded bg-emerald-600 flex-shrink-0 flex items-center justify-center text-[10px] font-bold text-white">
               {currentWorkspace?.name?.charAt(0) ?? ''}
             </div>
-            <span className="font-semibold text-sm text-slate-200 truncate">{currentWorkspace.name}</span>
-            <ChevronsUpDown className="w-3 h-3 text-slate-500" />
+            <span className="font-semibold text-sm text-text-secondary truncate">{currentWorkspace.name}</span>
+            <ChevronsUpDown className="w-3 h-3 text-text-faint" />
           </div>
           <button
             onClick={(e) => {
               e.stopPropagation();
               setIsOpen(false);
             }}
-            className="p-1 text-slate-400 hover:text-slate-100 hover:bg-slate-700/50 rounded opacity-0 group-hover:opacity-100 transition-opacity"
+            className="p-1 text-text-muted hover:text-text-primary hover:bg-border-subtle/50 rounded opacity-0 group-hover:opacity-100 transition-opacity"
           >
             <PanelLeftClose className="w-4 h-4" />
           </button>
@@ -132,15 +131,15 @@ export const Sidebar = () => {
 
         {/* Workspace Switcher Popover */}
         {isWorkspaceMenuOpen && (
-          <div className="absolute top-14 left-3 w-[260px] bg-[#1e1e1e] border border-slate-700 rounded-xl shadow-2xl overflow-hidden z-[100] animate-in fade-in zoom-in-95 duration-100">
+          <div className="absolute top-14 left-3 w-[260px] bg-surface-overlay border border-border-subtle rounded-xl shadow-2xl overflow-hidden z-[100] animate-in fade-in zoom-in-95 duration-100">
             {/* Current Workspace Header */}
-            <div className="p-4 bg-slate-800/30 border-b border-slate-700/50">
+            <div className="p-4 bg-hover-bg border-b border-border-subtle/50">
               <div className="flex items-center gap-3 mb-3">
                 <div className="w-10 h-10 rounded-lg bg-emerald-600 flex items-center justify-center text-lg font-bold text-white">
                   {currentWorkspace?.name?.charAt(0) ?? ''}
                 </div>
                 <div className="flex-1 overflow-hidden">
-                  <div className="font-bold text-slate-200 text-sm truncate">{currentWorkspace?.name}</div>
+                  <div className="font-bold text-text-secondary text-sm truncate">{currentWorkspace?.name}</div>
                 </div>
               </div>
               <div className="flex gap-2">
@@ -150,7 +149,7 @@ export const Sidebar = () => {
                     navigate('/settings');
                     setIsWorkspaceMenuOpen(false);
                   }}
-                  className="flex-1 py-1.5 text-xs text-slate-300 bg-slate-700/50 hover:bg-slate-700 rounded border border-slate-600/50 flex items-center justify-center gap-1.5 transition-colors"
+                  className="flex-1 py-1.5 text-xs text-text-secondary bg-border-subtle/50 hover:bg-border-subtle rounded border border-border-subtle/50 flex items-center justify-center gap-1.5 transition-colors"
                 >
                   <Settings className="w-3.5 h-3.5" /> 설정
                 </button>
@@ -160,7 +159,7 @@ export const Sidebar = () => {
                     navigate('/settings');
                     setIsWorkspaceMenuOpen(false);
                   }}
-                  className="flex-1 py-1.5 text-xs text-slate-300 bg-slate-700/50 hover:bg-slate-700 rounded border border-slate-600/50 flex items-center justify-center gap-1.5 transition-colors"
+                  className="flex-1 py-1.5 text-xs text-text-secondary bg-border-subtle/50 hover:bg-border-subtle rounded border border-border-subtle/50 flex items-center justify-center gap-1.5 transition-colors"
                 >
                   <UserPlus className="w-3.5 h-3.5" /> 멤버 초대
                 </button>
@@ -169,32 +168,32 @@ export const Sidebar = () => {
 
             {/* Workspace List */}
             <div className="py-2 max-h-[240px] overflow-y-auto">
-              <div className="px-3 py-1.5 text-xs font-medium text-slate-500">bookandpapers717@gmail.com</div>
+              <div className="px-3 py-1.5 text-xs font-medium text-text-faint">bookandpapers717@gmail.com</div>
               {workspaces.map(ws => (
                 <div
                   key={ws.id}
                   onClick={() => handleSwitchWorkspace(ws.id)}
-                  className="flex items-center justify-between px-3 py-2 hover:bg-slate-700/30 cursor-pointer group"
+                  className="flex items-center justify-between px-3 py-2 hover:bg-hover-bg cursor-pointer group"
                 >
                   <div className="flex items-center gap-2 overflow-hidden">
-                    <div className="w-6 h-6 rounded bg-slate-700 flex items-center justify-center text-xs font-medium text-slate-300">
+                    <div className="w-6 h-6 rounded bg-border-subtle flex items-center justify-center text-xs font-medium text-text-secondary">
                       {ws.name.charAt(0)}
                     </div>
-                    <span className={`text-sm truncate ${ws.id === currentWorkspaceId ? 'text-slate-100 font-medium' : 'text-slate-400'}`}>
+                    <span className={`text-sm truncate ${ws.id === currentWorkspaceId ? 'text-text-primary font-medium' : 'text-text-muted'}`}>
                       {ws.name}
                     </span>
                   </div>
                   {ws.id === currentWorkspaceId ? (
                     <Check className="w-4 h-4 text-emerald-500" />
                   ) : (
-                    <MoreHorizontal className="w-4 h-4 text-slate-500 opacity-0 group-hover:opacity-100" />
+                    <MoreHorizontal className="w-4 h-4 text-text-faint opacity-0 group-hover:opacity-100" />
                   )}
                 </div>
               ))}
 
               <div
                 onClick={handleCreateWorkspace}
-                className="flex items-center gap-2 px-3 py-2 hover:bg-slate-700/30 cursor-pointer text-slate-400 hover:text-slate-200 mt-1"
+                className="flex items-center gap-2 px-3 py-2 hover:bg-hover-bg cursor-pointer text-text-muted hover:text-text-secondary mt-1"
               >
                 <div className="w-6 h-6 flex items-center justify-center">
                   <Plus className="w-4 h-4" />
@@ -210,7 +209,7 @@ export const Sidebar = () => {
       {/* Main Navigation — 워크스페이스 스코프 메뉴 */}
       <div className="flex-1 px-2 py-4 overflow-y-auto flex flex-col">
         <div>
-          <div className="text-xs font-bold text-slate-400 mb-2 px-2 tracking-widest uppercase">메뉴</div>
+          <div className="text-xs font-bold text-text-muted mb-2 px-2 tracking-widest uppercase">메뉴</div>
           <div className="space-y-1">
             {menuItems.map((item, idx) => (
               <button
@@ -219,11 +218,11 @@ export const Sidebar = () => {
                 className={cn(
                   'w-full flex items-center gap-3 px-3 py-2 rounded-lg text-[15px] font-medium transition-colors group',
                   isMenuActive(item)
-                    ? 'bg-slate-800 text-slate-100'
-                    : 'text-slate-400 hover:text-slate-100 hover:bg-slate-800/50'
+                    ? 'bg-surface-subtle text-text-primary'
+                    : 'text-text-muted hover:text-text-primary hover:bg-hover-bg'
                 )}
               >
-                <item.icon className={cn("w-5 h-5", isMenuActive(item) ? "text-slate-100" : "text-slate-500 group-hover:text-slate-400")} />
+                <item.icon className={cn("w-5 h-5", isMenuActive(item) ? "text-text-primary" : "text-text-faint group-hover:text-text-muted")} />
                 <span className="flex-1 text-left">{item.label}</span>
               </button>
             ))}
@@ -232,30 +231,30 @@ export const Sidebar = () => {
 
         {/* 탐색 섹션 (글로벌) */}
         <div className="mt-8">
-          <div className="text-xs font-bold text-slate-400 mb-2 px-2 tracking-widest uppercase">탐색</div>
+          <div className="text-xs font-bold text-text-muted mb-2 px-2 tracking-widest uppercase">탐색</div>
           <button
             onClick={() => navigate('/explore')}
             className={cn(
               'w-full flex items-center gap-3 px-3 py-2 rounded-lg text-[15px] font-medium transition-colors group',
               location.pathname.startsWith('/explore')
-                ? 'bg-slate-800 text-slate-100'
-                : 'text-slate-400 hover:text-slate-100 hover:bg-slate-800/50'
+                ? 'bg-surface-subtle text-text-primary'
+                : 'text-text-muted hover:text-text-primary hover:bg-hover-bg'
             )}
           >
-            <Compass className={cn("w-5 h-5", location.pathname.startsWith('/explore') ? "text-slate-100" : "text-slate-500 group-hover:text-slate-400")} />
+            <Compass className={cn("w-5 h-5", location.pathname.startsWith('/explore') ? "text-text-primary" : "text-text-faint group-hover:text-text-muted")} />
             <span className="flex-1 text-left">워크스페이스 탐색</span>
           </button>
         </div>
       </div>
 
       {/* Bottom Settings Section */}
-      <div className="p-2 border-t border-slate-800/50 space-y-0.5">
+      <div className="p-2 border-t border-border-default/50 space-y-0.5">
         <button
           onClick={() => {
             setSettingsTab('general');
             navigate('/settings');
           }}
-          className="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-md text-sm font-medium text-slate-400 hover:text-slate-100 hover:bg-slate-800/50 transition-colors"
+          className="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-md text-sm font-medium text-text-muted hover:text-text-primary hover:bg-hover-bg transition-colors"
         >
           <SlidersHorizontal className="w-4 h-4" />
           <span className="flex-1 text-left">설정</span>
@@ -264,7 +263,7 @@ export const Sidebar = () => {
         {/* Logout */}
         <button
           onClick={handleLogout}
-          className="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-md text-sm font-medium text-slate-400 hover:text-red-400 hover:bg-slate-800/50 transition-colors"
+          className="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-md text-sm font-medium text-text-muted hover:text-red-600 dark:hover:text-red-400 hover:bg-hover-bg transition-colors"
         >
           <LogOut className="w-4 h-4" />
           <span className="flex-1 text-left">로그아웃</span>

--- a/src/components/modals/CreateWorkspaceModal.tsx
+++ b/src/components/modals/CreateWorkspaceModal.tsx
@@ -57,10 +57,10 @@ export const CreateWorkspaceModal = () => {
 
 
 
-      <div className="w-full max-w-lg bg-[#141820] border border-slate-700/50 rounded-2xl shadow-2xl p-8 relative">
+      <div className="w-full max-w-lg bg-surface border border-border-subtle/50 rounded-2xl shadow-2xl p-8 relative">
         <button
           onClick={() => setIsOpen(false)}
-          className="absolute top-6 left-6 p-2 rounded-lg bg-slate-800 text-slate-400 hover:text-white transition-colors"
+          className="absolute top-6 left-6 p-2 rounded-lg bg-surface-subtle text-text-muted hover:text-text-primary transition-colors"
         >
           <span className="sr-only">Close</span>
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -69,27 +69,27 @@ export const CreateWorkspaceModal = () => {
         </button>
 
         <div className="text-center mt-8 mb-10">
-          <h2 className="text-3xl font-bold text-white mb-2">워크스페이스 생성</h2>
+          <h2 className="text-3xl font-bold text-text-primary mb-2">워크스페이스 생성</h2>
         </div>
 
         <div className="space-y-6">
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-300">워크스페이스 이름</label>
+            <label className="text-sm font-medium text-text-secondary">워크스페이스 이름</label>
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full h-12 bg-slate-900/50 border border-slate-700 rounded-lg px-4 text-slate-200 focus:outline-none focus:border-indigo-500 transition-colors"
+              className="w-full h-12 bg-input-bg/50 border border-border-subtle rounded-lg px-4 text-text-secondary focus:outline-none focus:border-indigo-500 transition-colors"
             />
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-300">설명 <span className="text-slate-500">(선택)</span></label>
+            <label className="text-sm font-medium text-text-secondary">설명 <span className="text-text-faint">(선택)</span></label>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
-              className="w-full bg-slate-900/50 border border-slate-700 rounded-lg px-4 py-3 text-slate-200 focus:outline-none focus:border-indigo-500 transition-colors resize-none"
+              className="w-full bg-input-bg/50 border border-border-subtle rounded-lg px-4 py-3 text-text-secondary focus:outline-none focus:border-indigo-500 transition-colors resize-none"
               placeholder="워크스페이스에 대한 간단한 설명을 입력하세요"
             />
           </div>
@@ -108,7 +108,7 @@ export const CreateWorkspaceModal = () => {
             {isSubmitting ? '생성 중...' : '생성하기'}
           </Button>
 
-          <p className="text-center text-xs text-slate-500 mt-4">
+          <p className="text-center text-xs text-text-faint mt-4">
             생성 후에도 워크스페이스 이름은 언제든 변경할 수 있습니다.
           </p>
         </div>

--- a/src/components/ui/Base.tsx
+++ b/src/components/ui/Base.tsx
@@ -16,10 +16,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant = 'primary', size = 'md', ...props }, ref) => {
     const variants = {
       primary: 'bg-emerald-600 text-white hover:bg-emerald-700 active:bg-emerald-800 shadow-sm shadow-emerald-900/20',
-      secondary: 'bg-slate-800 text-slate-200 hover:bg-slate-700 active:bg-slate-600 border border-slate-700',
-      ghost: 'bg-transparent text-slate-400 hover:text-slate-100 hover:bg-slate-800/50',
+      secondary: 'bg-surface-subtle text-text-secondary hover:bg-border-subtle active:bg-border-default border border-border-subtle',
+      ghost: 'bg-transparent text-text-muted hover:text-text-primary hover:bg-hover-bg',
       danger: 'bg-red-500/10 text-red-500 hover:bg-red-500/20 border border-red-500/20',
-      outline: 'bg-transparent border border-slate-700 text-slate-300 hover:bg-slate-800/50 hover:text-slate-100',
+      outline: 'bg-transparent border border-border-subtle text-text-secondary hover:bg-hover-bg hover:text-text-primary',
     };
 
     const sizes = {
@@ -47,7 +47,7 @@ Button.displayName = 'Button';
 interface CardProps extends HTMLAttributes<HTMLDivElement> { }
 
 export const Card = ({ className, children, ...props }: CardProps) => (
-  <div className={cn('bg-slate-900/50 border border-slate-800 rounded-xl overflow-hidden backdrop-blur-sm', className)} {...props}>
+  <div className={cn('bg-surface/50 border border-border-default rounded-xl overflow-hidden backdrop-blur-sm', className)} {...props}>
     {children}
   </div>
 );
@@ -58,12 +58,12 @@ interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
 
 export const Badge = ({ className, variant = 'default', children, ...props }: BadgeProps) => {
   const variants = {
-    default: 'bg-slate-800 text-slate-300 border-slate-700',
-    success: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
-    warning: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
-    destructive: 'bg-red-500/10 text-red-400 border-red-500/20',
-    outline: 'bg-transparent border-slate-700 text-slate-400',
-    secondary: 'bg-slate-800/50 text-slate-400 border-slate-700/50',
+    default: 'bg-surface-subtle text-text-secondary border-border-subtle',
+    success: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20',
+    warning: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20',
+    destructive: 'bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20',
+    outline: 'bg-transparent border-border-subtle text-text-muted',
+    secondary: 'bg-surface-subtle/50 text-text-muted border-border-subtle/50',
   };
   return (
     <span className={cn('inline-flex items-center px-2 py-0.5 rounded text-xs font-medium border', variants[variant], className)} {...props}>
@@ -84,7 +84,7 @@ export const Avatar = ({ className, src, alt, fallback, ...props }: AvatarProps)
       {src ? (
         <img className="aspect-square h-full w-full" src={src} alt={alt} />
       ) : (
-        <div className="flex h-full w-full items-center justify-center rounded-full bg-slate-800">
+        <div className="flex h-full w-full items-center justify-center rounded-full bg-surface-subtle">
           {fallback}
         </div>
       )}
@@ -106,14 +106,14 @@ export const Modal = ({ isOpen, onClose, title, children }: ModalProps) => {
     <div className="fixed inset-0 z-50 flex items-center justify-center overflow-x-hidden overflow-y-auto outline-none focus:outline-none">
       <div className="fixed inset-0 bg-black/60 backdrop-blur-sm transition-opacity" onClick={onClose} />
       <div className="relative w-full max-w-lg mx-auto my-6 z-50">
-        <div className="relative flex flex-col w-full bg-[#141820] border border-slate-800 rounded-xl shadow-2xl outline-none focus:outline-none">
+        <div className="relative flex flex-col w-full bg-surface border border-border-default rounded-xl shadow-2xl outline-none focus:outline-none">
           {/* Header */}
-          <div className="flex items-center justify-between p-5 border-b border-slate-800 rounded-t">
-            <h3 className="text-xl font-semibold text-slate-100">
+          <div className="flex items-center justify-between p-5 border-b border-border-default rounded-t">
+            <h3 className="text-xl font-semibold text-text-primary">
               {title}
             </h3>
             <button
-              className="p-1 ml-auto bg-transparent border-0 text-slate-400 float-right text-3xl leading-none font-semibold outline-none focus:outline-none hover:text-slate-100 transition-colors"
+              className="p-1 ml-auto bg-transparent border-0 text-text-muted float-right text-3xl leading-none font-semibold outline-none focus:outline-none hover:text-text-primary transition-colors"
               onClick={onClose}
             >
               <X className="w-5 h-5" />

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as React from "react";
-import { GripVerticalIcon } from "lucide-react";
 import * as ResizablePrimitive from "react-resizable-panels";
 
 import { cn } from "./utils";
@@ -39,14 +38,14 @@ function ResizableHandle({
     <ResizablePrimitive.PanelResizeHandle
       data-slot="resizable-handle"
       className={cn(
-        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90 [&:hover>div>span]:bg-text-faint",
         className,
       )}
       {...props}
     >
       {withHandle && (
-        <div className="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-xs border">
-          <GripVerticalIcon className="size-2.5" />
+        <div className="z-10 flex items-center justify-center">
+          <span className="w-[3px] h-8 rounded-full bg-text-faint/80 transition-colors duration-200 hover:bg-text-muted" />
         </div>
       )}
     </ResizablePrimitive.PanelResizeHandle>

--- a/src/features/auth/Login.tsx
+++ b/src/features/auth/Login.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
-import { userState, workspacesState, currentWorkspaceState } from '@/store/atoms';
+import { userState, workspacesState } from '@/store/atoms';
 import { loginApi } from '@/api/auth';
 import { getMe } from '@/api/user';
 import { Button, Card } from '@/components/ui/Base';
@@ -16,7 +16,6 @@ export const Login = ({ oauthError, onClearError }: LoginProps) => {
   const navigate = useNavigate();
   const setUser = useSetRecoilState(userState);
   const setWorkspaces = useSetRecoilState(workspacesState);
-  const setCurrentWsId = useSetRecoilState(currentWorkspaceState);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -57,7 +56,6 @@ export const Login = ({ oauthError, onClearError }: LoginProps) => {
       localStorage.setItem('auth', JSON.stringify(userData));
 
       setWorkspaces([]);
-      setCurrentWsId(0);
       setUser(userData);
 
       setLoading(false);
@@ -71,37 +69,37 @@ export const Login = ({ oauthError, onClearError }: LoginProps) => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#0F1117] p-4">
-      <Card className="w-full max-w-md p-8 bg-[#141820] border-slate-800">
+    <div className="min-h-screen flex items-center justify-center bg-page p-4">
+      <Card className="w-full max-w-md p-8 bg-surface border-border-default">
         <div className="text-center mb-8">
-          <h1 className="text-2xl font-bold text-slate-100 mb-2">로그인</h1>
-          <p className="text-slate-400 text-sm">알고리즘 문제 풀이 플랫폼에 오신 것을 환영합니다.</p>
+          <h1 className="text-2xl font-bold text-text-primary mb-2">로그인</h1>
+          <p className="text-text-muted text-sm">알고리즘 문제 풀이 플랫폼에 오신 것을 환영합니다.</p>
         </div>
 
         <form onSubmit={handleLogin} className="space-y-4">
           <div className="space-y-1">
-            <label className="text-xs font-medium text-slate-400">이메일</label>
+            <label className="text-xs font-medium text-text-muted">이메일</label>
             <div className="relative">
-              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-faint" />
               <input
                 type="email"
                 value={email}
                 onChange={(e) => { setEmail(e.target.value); clearOauthError(); }}
-                className="w-full bg-slate-900 border border-slate-800 rounded-lg py-2.5 pl-10 pr-4 text-sm text-slate-200 focus:outline-none focus:border-emerald-500 transition-colors"
+                className="w-full bg-input-bg border border-border-default rounded-lg py-2.5 pl-10 pr-4 text-sm text-text-secondary focus:outline-none focus:border-emerald-500 transition-colors"
                 placeholder="name@example.com"
               />
             </div>
           </div>
 
           <div className="space-y-1">
-            <label className="text-xs font-medium text-slate-400">비밀번호</label>
+            <label className="text-xs font-medium text-text-muted">비밀번호</label>
             <div className="relative">
-              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-faint" />
               <input
                 type="password"
                 value={password}
                 onChange={(e) => { setPassword(e.target.value); clearOauthError(); }}
-                className="w-full bg-slate-900 border border-slate-800 rounded-lg py-2.5 pl-10 pr-4 text-sm text-slate-200 focus:outline-none focus:border-emerald-500 transition-colors"
+                className="w-full bg-input-bg border border-border-default rounded-lg py-2.5 pl-10 pr-4 text-sm text-text-secondary focus:outline-none focus:border-emerald-500 transition-colors"
                 placeholder="••••••••"
               />
             </div>
@@ -117,14 +115,14 @@ export const Login = ({ oauthError, onClearError }: LoginProps) => {
         </form>
 
         <div className="relative my-6">
-          <div className="absolute inset-0 flex items-center"><div className="w-full border-t border-slate-800"></div></div>
-          <div className="relative flex justify-center text-xs uppercase"><span className="bg-[#141820] px-2 text-slate-500">또는 소셜 계정으로 로그인</span></div>
+          <div className="absolute inset-0 flex items-center"><div className="w-full border-t border-border-default"></div></div>
+          <div className="relative flex justify-center text-xs uppercase"><span className="bg-surface px-2 text-text-faint">또는 소셜 계정으로 로그인</span></div>
         </div>
 
         <div className="grid grid-cols-2 gap-3">
           <a
             href="/oauth2/authorization/google"
-            className="flex items-center justify-center gap-2 bg-slate-900 border border-slate-800 rounded-lg py-2 text-sm text-slate-300 hover:bg-slate-800 transition-colors"
+            className="flex items-center justify-center gap-2 bg-input-bg border border-border-default rounded-lg py-2 text-sm text-text-secondary hover:bg-surface-subtle transition-colors"
           >
             <svg className="w-4 h-4" viewBox="0 0 24 24"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" /><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" /><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" /><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" /></svg> Google
           </a>
@@ -136,7 +134,7 @@ export const Login = ({ oauthError, onClearError }: LoginProps) => {
           </a>
         </div>
 
-        <div className="mt-6 text-center text-sm text-slate-400">
+        <div className="mt-6 text-center text-sm text-text-muted">
           계정이 없으신가요?{' '}
           <button onClick={() => navigate('/signup')} className="text-emerald-500 hover:text-emerald-400 font-medium">
             회원가입

--- a/src/features/auth/OAuthCallback.tsx
+++ b/src/features/auth/OAuthCallback.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
-import { userState, workspacesState, currentWorkspaceState } from '@/store/atoms';
+import { userState, workspacesState } from '@/store/atoms';
 import { getMe } from '@/api/user';
 
 interface Props {
@@ -11,7 +11,6 @@ interface Props {
 export const OAuthCallback = ({ onComplete }: Props) => {
   const setUser = useSetRecoilState(userState);
   const setWorkspaces = useSetRecoilState(workspacesState);
-  const setCurrentWsId = useSetRecoilState(currentWorkspaceState);
   const navigate = useNavigate();
   // Use a ref to prevent double execution in strict mode
   const processedRef = useRef(false);
@@ -61,7 +60,6 @@ export const OAuthCallback = ({ onComplete }: Props) => {
 
           localStorage.setItem('auth', JSON.stringify(userData));
           setWorkspaces([]);
-          setCurrentWsId(0);
           setUser(userData);
 
           navigate('/', { replace: true });

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -87,24 +87,24 @@ export const SignUp = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#0F1117] p-4">
-      <Card className="w-full max-w-md p-8 bg-[#141820] border-slate-800">
+    <div className="min-h-screen flex items-center justify-center bg-page p-4">
+      <Card className="w-full max-w-md p-8 bg-surface border-border-default">
         <div className="text-center mb-8">
-          <h1 className="text-2xl font-bold text-slate-100 mb-2">회원가입</h1>
-          <p className="text-slate-400 text-sm">개발자 커뮤니티에 참여하세요.</p>
+          <h1 className="text-2xl font-bold text-text-primary mb-2">회원가입</h1>
+          <p className="text-text-muted text-sm">개발자 커뮤니티에 참여하세요.</p>
         </div>
 
         <form onSubmit={handleSignup} className="space-y-4">
           <div className="space-y-1">
-            <label className="text-xs font-medium text-slate-400">이메일</label>
+            <label className="text-xs font-medium text-text-muted">이메일</label>
             <div className="relative">
-              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-faint" />
               <input
                 type="email"
                 name="email"
                 value={formData.email}
                 onChange={handleChange}
-                className={`w-full bg-slate-900 border ${errors.email ? 'border-red-500' : 'border-slate-800'} rounded-lg py-2.5 pl-10 pr-4 text-sm text-slate-200 focus:outline-none focus:border-emerald-500 transition-colors`}
+                className={`w-full bg-input-bg border ${errors.email ? 'border-red-500' : 'border-border-default'} rounded-lg py-2.5 pl-10 pr-4 text-sm text-text-secondary focus:outline-none focus:border-emerald-500 transition-colors`}
                 placeholder="name@example.com"
               />
             </div>
@@ -112,40 +112,40 @@ export const SignUp = () => {
           </div>
 
           <div className="space-y-1">
-            <label className="text-xs font-medium text-slate-400">닉네임</label>
+            <label className="text-xs font-medium text-text-muted">닉네임</label>
             <div className="relative">
-              <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+              <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-faint" />
               <input
                 type="text"
                 name="nickname"
                 value={formData.nickname}
                 onChange={handleChange}
-                className="w-full bg-slate-900 border border-slate-800 rounded-lg py-2.5 pl-10 pr-4 text-sm text-slate-200 focus:outline-none focus:border-emerald-500 transition-colors"
+                className="w-full bg-input-bg border border-border-default rounded-lg py-2.5 pl-10 pr-4 text-sm text-text-secondary focus:outline-none focus:border-emerald-500 transition-colors"
                 placeholder="DevMaster"
               />
             </div>
           </div>
 
           <div className="space-y-1">
-            <label className="text-xs font-medium text-slate-400">비밀번호</label>
+            <label className="text-xs font-medium text-text-muted">비밀번호</label>
             <div className="relative">
-              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-faint" />
               <input
                 type="password"
                 name="password"
                 value={formData.password}
                 onChange={handleChange}
-                className={`w-full bg-slate-900 border ${errors.password ? 'border-red-500' : 'border-slate-800'} rounded-lg py-2.5 pl-10 pr-4 text-sm text-slate-200 focus:outline-none focus:border-emerald-500 transition-colors`}
+                className={`w-full bg-input-bg border ${errors.password ? 'border-red-500' : 'border-border-default'} rounded-lg py-2.5 pl-10 pr-4 text-sm text-text-secondary focus:outline-none focus:border-emerald-500 transition-colors`}
                 placeholder="••••••••"
               />
             </div>
 
             {/* Password Validation Feedback Area */}
             <div className="grid grid-cols-2 gap-2 mt-2">
-              <div className={`text-xs flex items-center gap-1 ${formData.password.length >= 8 ? 'text-emerald-500' : 'text-slate-600'}`}>
+              <div className={`text-xs flex items-center gap-1 ${formData.password.length >= 8 ? 'text-emerald-500' : 'text-text-faint'}`}>
                 <CheckCircle2 className="w-3 h-3" /> 8자 이상
               </div>
-              <div className={`text-xs flex items-center gap-1 ${/[0-9]/.test(formData.password) ? 'text-emerald-500' : 'text-slate-600'}`}>
+              <div className={`text-xs flex items-center gap-1 ${/[0-9]/.test(formData.password) ? 'text-emerald-500' : 'text-text-faint'}`}>
                 <CheckCircle2 className="w-3 h-3" /> 숫자 포함
               </div>
             </div>
@@ -162,7 +162,7 @@ export const SignUp = () => {
           </Button>
         </form>
 
-        <div className="mt-6 text-center text-sm text-slate-400">
+        <div className="mt-6 text-center text-sm text-text-muted">
           이미 계정이 있으신가요?{' '}
           <button onClick={() => navigate('/login')} className="text-emerald-500 hover:text-emerald-400 font-medium">
             로그인

--- a/src/features/challenges/ChallengeDetail.tsx
+++ b/src/features/challenges/ChallengeDetail.tsx
@@ -34,12 +34,12 @@ export const ChallengeDetail = () => {
   const ranking = participants.sort((a, b) => b.score - a.score).slice(0, 5);
 
   return (
-    <div className="flex-1 overflow-y-auto bg-[#0F1117] p-8">
+    <div className="flex-1 overflow-y-auto bg-page p-8">
       <div className="max-w-6xl mx-auto space-y-8">
 
         {/* Header */}
         <div className="flex flex-col gap-6">
-          <Button variant="ghost" className="w-fit -ml-2 text-slate-400" onClick={() => toWs('challenges')}>
+          <Button variant="ghost" className="w-fit -ml-2 text-text-muted" onClick={() => toWs('challenges')}>
             <ArrowLeft className="w-4 h-4 mr-2" /> 챌린지 목록
           </Button>
 
@@ -51,25 +51,25 @@ export const ChallengeDetail = () => {
                 ) : (
                   <div className="flex items-center gap-2">
                     <Badge variant="success">Day 12</Badge>
-                    <span className="text-slate-500 text-sm">/ {currentChallenge.duration}</span>
+                    <span className="text-text-faint text-sm">/ {currentChallenge.duration}</span>
                   </div>
                 )}
               </div>
-              <h1 className="text-3xl font-bold text-slate-100">{currentChallenge.title}</h1>
+              <h1 className="text-3xl font-bold text-text-primary">{currentChallenge.title}</h1>
             </div>
 
             {/* Timer or Result Badge */}
             <div className="text-right">
               {isEndedView ? (
                 <div className="flex flex-col items-end">
-                  <span className="text-sm text-slate-400 mb-1">Final Status</span>
+                  <span className="text-sm text-text-muted mb-1">Final Status</span>
                   <span className="text-xl font-bold text-emerald-500 flex items-center gap-2">
                     <CheckCircle2 className="w-5 h-5" /> Completed
                   </span>
                 </div>
               ) : (
                 <>
-                  <div className="text-sm text-slate-400 mb-1">남은 시간</div>
+                  <div className="text-sm text-text-muted mb-1">남은 시간</div>
                   <div className="text-2xl font-mono font-bold text-emerald-500">14:22:05</div>
                 </>
               )}
@@ -77,16 +77,16 @@ export const ChallengeDetail = () => {
           </div>
 
           {/* Progress Bar (Show in both but different context) */}
-          <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-6">
+          <div className="bg-input-bg/50 border border-border-default rounded-xl p-6">
             <div className="flex justify-between text-sm mb-2">
-              <span className="text-slate-300">
+              <span className="text-text-secondary">
                 {isEndedView ? '최종 달성률' : '전체 진행률'}
               </span>
               <span className="text-emerald-500 font-bold">
                 {isEndedView ? '92%' : '40%'}
               </span>
             </div>
-            <div className="w-full bg-slate-800 rounded-full h-3 overflow-hidden">
+            <div className="w-full bg-surface-subtle rounded-full h-3 overflow-hidden">
               <div
                 className={`h-full bg-gradient-to-r from-emerald-600 to-emerald-400 relative ${isEndedView ? 'w-[92%]' : 'w-2/5'}`}
               >
@@ -94,16 +94,16 @@ export const ChallengeDetail = () => {
               </div>
             </div>
             <div className="grid grid-cols-3 gap-4 mt-6">
-              <div className="text-center p-3 bg-slate-800/30 rounded-lg">
-                <div className="text-xs text-slate-500 mb-1">{isEndedView ? '완주자' : '생존자'}</div>
-                <div className="text-xl font-bold text-slate-200">124<span className="text-slate-500 text-sm font-normal">/156</span></div>
+              <div className="text-center p-3 bg-surface-subtle/30 rounded-lg">
+                <div className="text-xs text-text-faint mb-1">{isEndedView ? '완주자' : '생존자'}</div>
+                <div className="text-xl font-bold text-text-secondary">124<span className="text-text-faint text-sm font-normal">/156</span></div>
               </div>
-              <div className="text-center p-3 bg-slate-800/30 rounded-lg">
-                <div className="text-xs text-slate-500 mb-1">평균 문제 해결</div>
-                <div className="text-xl font-bold text-slate-200">{isEndedView ? '28.5' : '12'}</div>
+              <div className="text-center p-3 bg-surface-subtle/30 rounded-lg">
+                <div className="text-xs text-text-faint mb-1">평균 문제 해결</div>
+                <div className="text-xl font-bold text-text-secondary">{isEndedView ? '28.5' : '12'}</div>
               </div>
-              <div className="text-center p-3 bg-slate-800/30 rounded-lg">
-                <div className="text-xs text-slate-500 mb-1">총 상금 포인트</div>
+              <div className="text-center p-3 bg-surface-subtle/30 rounded-lg">
+                <div className="text-xs text-text-faint mb-1">총 상금 포인트</div>
                 <div className="text-xl font-bold text-yellow-500">50,000 P</div>
               </div>
             </div>
@@ -118,13 +118,13 @@ export const ChallengeDetail = () => {
             {isEndedView ? (
               /* ENDED VIEW: Ranking & Results */
               <>
-                <h2 className="text-xl font-bold text-slate-200 flex items-center gap-2">
+                <h2 className="text-xl font-bold text-text-secondary flex items-center gap-2">
                   <Medal className="w-5 h-5 text-yellow-500" /> 최종 랭킹
                 </h2>
-                <div className="bg-slate-900/50 border border-slate-800 rounded-xl overflow-hidden">
+                <div className="bg-input-bg/50 border border-border-default rounded-xl overflow-hidden">
                   <table className="w-full text-left border-collapse">
                     <thead>
-                      <tr className="border-b border-slate-800 bg-[#141820] text-slate-400 text-sm">
+                      <tr className="border-b border-border-default bg-surface text-text-muted text-sm">
                         <th className="p-4 font-medium w-16 text-center">Rank</th>
                         <th className="p-4 font-medium">User</th>
                         <th className="p-4 font-medium text-center">Solved</th>
@@ -132,27 +132,27 @@ export const ChallengeDetail = () => {
                         <th className="p-4 font-medium text-center">Code</th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-slate-800/50">
+                    <tbody className="divide-y divide-border-default">
                       {ranking.map((user, idx) => (
-                        <tr key={user.id} className="hover:bg-slate-800/30 transition-colors">
+                        <tr key={user.id} className="hover:bg-hover-bg transition-colors">
                           <td className="p-4 text-center">
                             {idx === 0 ? <span className="text-xl">🥇</span> :
                               idx === 1 ? <span className="text-xl">🥈</span> :
                                 idx === 2 ? <span className="text-xl">🥉</span> :
-                                  <span className="text-slate-500 font-mono">#{user.rank}</span>}
+                                  <span className="text-text-faint font-mono">#{user.rank}</span>}
                           </td>
                           <td className="p-4">
                             <div className="flex items-center gap-3">
-                              <div className="w-8 h-8 rounded-full bg-slate-700 overflow-hidden">
+                              <div className="w-8 h-8 rounded-full bg-surface-subtle overflow-hidden">
                                 <img src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${user.id}`} alt={user.name} />
                               </div>
-                              <span className="text-slate-200 font-medium">{user.name}</span>
+                              <span className="text-text-secondary font-medium">{user.name}</span>
                             </div>
                           </td>
-                          <td className="p-4 text-center text-slate-400">{user.solvedCount}</td>
+                          <td className="p-4 text-center text-text-muted">{user.solvedCount}</td>
                           <td className="p-4 text-right font-mono text-emerald-400">{user.score.toLocaleString()}</td>
                           <td className="p-4 text-center">
-                            <button className="text-slate-500 hover:text-emerald-500 transition-colors" title="View Code">
+                            <button className="text-text-faint hover:text-emerald-500 transition-colors" title="View Code">
                               <Code2 className="w-4 h-4 mx-auto" />
                             </button>
                           </td>
@@ -165,18 +165,18 @@ export const ChallengeDetail = () => {
             ) : (
               /* ACTIVE VIEW: Daily Mission */
               <>
-                <h2 className="text-xl font-bold text-slate-200 flex items-center gap-2">
+                <h2 className="text-xl font-bold text-text-secondary flex items-center gap-2">
                   <Calendar className="w-5 h-5 text-emerald-500" /> 오늘의 미션
                 </h2>
 
-                <div className="bg-gradient-to-br from-slate-900 to-slate-900/50 border border-slate-700/50 rounded-2xl p-6 relative overflow-hidden group hover:border-emerald-500/50 transition-colors">
+                <div className="bg-gradient-to-br from-surface-raised to-surface dark:from-slate-900 dark:to-slate-900/50 border border-border-subtle/50 rounded-2xl p-6 relative overflow-hidden group hover:border-emerald-500/50 transition-colors">
                   <div className="absolute top-0 right-0 p-4 opacity-10 group-hover:opacity-20 transition-opacity">
                     <Trophy className="w-32 h-32 text-emerald-500" />
                   </div>
 
                   <div className="relative z-10">
-                    <Badge className="bg-emerald-500/10 text-emerald-400 mb-3 border-emerald-500/20">Today's Problem</Badge>
-                    <h3 className="text-2xl font-bold text-white mb-2">1920. 수 찾기</h3>
+                    <Badge className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 mb-3 border-emerald-500/20">Today's Problem</Badge>
+                    <h3 className="text-2xl font-bold text-text-primary mb-2">1920. 수 찾기</h3>
                     <div className="flex gap-2 mb-6">
                       <Badge variant="secondary">Silver 4</Badge>
                       <Badge variant="secondary">Binary Search</Badge>
@@ -194,12 +194,12 @@ export const ChallengeDetail = () => {
                 </div>
 
                 {/* Upcoming Schedule (Mini) */}
-                <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-6">
-                  <h3 className="font-bold text-slate-200 mb-4">내일 예고</h3>
-                  <div className="flex items-center gap-4 text-slate-400">
-                    <div className="w-12 h-12 rounded-lg bg-slate-800 flex items-center justify-center font-bold text-slate-500">?</div>
+                <div className="bg-input-bg/50 border border-border-default rounded-xl p-6">
+                  <h3 className="font-bold text-text-secondary mb-4">내일 예고</h3>
+                  <div className="flex items-center gap-4 text-text-muted">
+                    <div className="w-12 h-12 rounded-lg bg-surface-subtle flex items-center justify-center font-bold text-text-faint">?</div>
                     <div>
-                      <div className="font-semibold text-slate-300">내일 00:00 공개</div>
+                      <div className="font-semibold text-text-secondary">내일 00:00 공개</div>
                       <div className="text-sm">난이도: Gold 5 예상</div>
                     </div>
                   </div>
@@ -210,23 +210,23 @@ export const ChallengeDetail = () => {
 
           {/* Sidebar: Participants */}
           <div className="space-y-6">
-            <h2 className="text-xl font-bold text-slate-200 flex items-center gap-2">
+            <h2 className="text-xl font-bold text-text-secondary flex items-center gap-2">
               <Flame className="w-5 h-5 text-orange-500" /> {isEndedView ? '참가자' : '생존자 현황'}
             </h2>
 
-            <div className="bg-slate-900/50 border border-slate-800 rounded-xl overflow-hidden">
-              <div className="p-4 border-b border-slate-800 bg-slate-900/80">
-                <div className="flex justify-between text-xs font-medium text-slate-400 uppercase tracking-wider">
+            <div className="bg-input-bg/50 border border-border-default rounded-xl overflow-hidden">
+              <div className="p-4 border-b border-border-default bg-input-bg/80">
+                <div className="flex justify-between text-xs font-medium text-text-muted uppercase tracking-wider">
                   <span>Member</span>
                   <span>{isEndedView ? 'Score' : 'Streak'}</span>
                 </div>
               </div>
-              <div className="divide-y divide-slate-800/50 max-h-[400px] overflow-y-auto">
+              <div className="divide-y divide-border-default max-h-[400px] overflow-y-auto">
                 {participants.map((p) => (
-                  <div key={p.id} className="p-3 flex items-center justify-between hover:bg-slate-800/30 transition-colors">
+                  <div key={p.id} className="p-3 flex items-center justify-between hover:bg-hover-bg transition-colors">
                     <div className="flex items-center gap-3">
                       <div className="relative">
-                        <div className="w-8 h-8 rounded-full bg-slate-700 overflow-hidden">
+                        <div className="w-8 h-8 rounded-full bg-surface-subtle overflow-hidden">
                           <img src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${p.id}`} alt={p.name} />
                         </div>
                         {!isEndedView && p.status === 'dropped' && (
@@ -235,7 +235,7 @@ export const ChallengeDetail = () => {
                           </div>
                         )}
                       </div>
-                      <span className={`text-sm font-medium ${!isEndedView && p.status === 'dropped' ? 'text-slate-500 line-through' : 'text-slate-200'}`}>
+                      <span className={`text-sm font-medium ${!isEndedView && p.status === 'dropped' ? 'text-text-faint line-through' : 'text-text-secondary'}`}>
                         {p.name}
                       </span>
                     </div>

--- a/src/features/challenges/ChallengeList.tsx
+++ b/src/features/challenges/ChallengeList.tsx
@@ -88,13 +88,13 @@ export const ChallengeList = () => {
   const endedChallenges = challenges.filter(c => c.status === 'ended');
 
   return (
-    <div className="flex-1 overflow-y-auto bg-[#0F1117] p-8">
+    <div className="flex-1 overflow-y-auto bg-page p-8">
       <div className="max-w-7xl mx-auto space-y-12">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-slate-100">챌린지 & 대회</h1>
-            <p className="text-slate-400 mt-1">동료들과 함께 성장하는 즐거움을 경험하세요.</p>
+            <h1 className="text-2xl font-bold text-text-primary">챌린지 & 대회</h1>
+            <p className="text-text-muted mt-1">동료들과 함께 성장하는 즐거움을 경험하세요.</p>
           </div>
           <Button className="gap-2 bg-emerald-600 hover:bg-emerald-700" onClick={() => setIsModalOpen(true)}>
             <Plus className="w-4 h-4" /> 챌린지 생성
@@ -103,7 +103,7 @@ export const ChallengeList = () => {
 
         {/* Active & Recruiting Section */}
         <section className="space-y-6">
-          <div className="flex items-center gap-2 text-lg font-bold text-slate-200">
+          <div className="flex items-center gap-2 text-lg font-bold text-text-secondary">
             <Trophy className="w-5 h-5 text-emerald-500" /> 진행중인 챌린지
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -114,12 +114,12 @@ export const ChallengeList = () => {
                   setCurrentChallenge(challenge);
                   toWs(`challenges/${challenge.id}`);
                 }}
-                className="group relative overflow-hidden bg-slate-900/50 border border-slate-800 rounded-xl p-6 cursor-pointer hover:bg-slate-800/50 hover:border-slate-700 transition-all"
+                className="group relative overflow-hidden bg-input-bg/50 border border-border-default rounded-xl p-6 cursor-pointer hover:bg-hover-bg hover:border-border-subtle transition-all"
               >
                 <div className={`absolute top-0 left-0 w-1 h-full ${challenge.color}`}></div>
 
                 <div className="flex justify-between items-start mb-4 pl-2">
-                  <div className={`w-10 h-10 rounded-lg ${challenge.color} bg-opacity-20 flex items-center justify-center text-slate-200`}>
+                  <div className={`w-10 h-10 rounded-lg ${challenge.color} bg-opacity-20 flex items-center justify-center text-text-secondary`}>
                     <Trophy className="w-5 h-5" />
                   </div>
                   <Badge variant={challenge.status === 'active' ? 'success' : 'warning'}>
@@ -127,30 +127,30 @@ export const ChallengeList = () => {
                   </Badge>
                 </div>
 
-                <h3 className="text-lg font-bold text-slate-200 mb-2 group-hover:text-emerald-400 transition-colors pl-2">
+                <h3 className="text-lg font-bold text-text-secondary mb-2 group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors pl-2">
                   {challenge.title}
                 </h3>
 
-                <div className="space-y-3 pl-2 text-sm text-slate-400 mt-4">
+                <div className="space-y-3 pl-2 text-sm text-text-muted mt-4">
                   <div className="flex items-center gap-2">
-                    <Users className="w-4 h-4 text-slate-500" />
+                    <Users className="w-4 h-4 text-text-faint" />
                     <span>{challenge.participants}명 참가 중</span>
                   </div>
                   <div className="flex items-center gap-2">
-                    <Clock className="w-4 h-4 text-slate-500" />
+                    <Clock className="w-4 h-4 text-text-faint" />
                     <span>{challenge.duration} ({challenge.startDate} 시작)</span>
                   </div>
                   <div className="flex items-center gap-2">
-                    <Target className="w-4 h-4 text-slate-500" />
+                    <Target className="w-4 h-4 text-text-faint" />
                     <span className="text-emerald-500">{challenge.reward}</span>
                   </div>
                 </div>
 
                 <div className="mt-6 pl-2">
-                  <div className="w-full bg-slate-800 rounded-full h-1.5 overflow-hidden">
+                  <div className="w-full bg-surface-subtle rounded-full h-1.5 overflow-hidden">
                     <div className={`h-full ${challenge.color} w-3/4`}></div>
                   </div>
-                  <div className="flex justify-between mt-2 text-xs text-slate-500">
+                  <div className="flex justify-between mt-2 text-xs text-text-faint">
                     <span>진행률 75%</span>
                     <span>D-7</span>
                   </div>
@@ -161,9 +161,9 @@ export const ChallengeList = () => {
         </section>
 
         {/* Ended Challenges Section */}
-        <section className="space-y-6 pt-6 border-t border-slate-800/50">
-          <div className="flex items-center gap-2 text-lg font-bold text-slate-200">
-            <Archive className="w-5 h-5 text-slate-500" /> 종료된 챌린지
+        <section className="space-y-6 pt-6 border-t border-border-default/50">
+          <div className="flex items-center gap-2 text-lg font-bold text-text-secondary">
+            <Archive className="w-5 h-5 text-text-faint" /> 종료된 챌린지
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {endedChallenges.map((challenge) => (
@@ -173,33 +173,33 @@ export const ChallengeList = () => {
                   setCurrentChallenge(challenge);
                   toWs(`challenges/${challenge.id}`);
                 }}
-                className="group relative overflow-hidden bg-slate-900/30 border border-slate-800 rounded-xl p-6 cursor-pointer hover:bg-slate-800/50 hover:border-slate-700 transition-all grayscale hover:grayscale-0"
+                className="group relative overflow-hidden bg-input-bg/30 border border-border-default rounded-xl p-6 cursor-pointer hover:bg-hover-bg hover:border-border-subtle transition-all grayscale hover:grayscale-0"
               >
-                <div className={`absolute top-0 left-0 w-1 h-full bg-slate-600`}></div>
+                <div className={`absolute top-0 left-0 w-1 h-full bg-border-subtle`}></div>
 
                 <div className="flex justify-between items-start mb-4 pl-2">
-                  <div className="w-10 h-10 rounded-lg bg-slate-800 flex items-center justify-center text-slate-500">
+                  <div className="w-10 h-10 rounded-lg bg-surface-subtle flex items-center justify-center text-text-faint">
                     <Archive className="w-5 h-5" />
                   </div>
                   <Badge variant="secondary">종료</Badge>
                 </div>
 
-                <h3 className="text-lg font-bold text-slate-300 mb-2 group-hover:text-white transition-colors pl-2">
+                <h3 className="text-lg font-bold text-text-secondary mb-2 group-hover:text-text-primary transition-colors pl-2">
                   {challenge.title}
                 </h3>
 
-                <div className="pl-2 text-sm text-slate-500 mb-4 h-10 line-clamp-2">
+                <div className="pl-2 text-sm text-text-faint mb-4 h-10 line-clamp-2">
                   {challenge.description}
                 </div>
 
-                <div className="space-y-2 pl-2 text-xs text-slate-500 border-t border-slate-800 pt-3">
+                <div className="space-y-2 pl-2 text-xs text-text-faint border-t border-border-default pt-3">
                   <div className="flex justify-between">
                     <span>참여자</span>
-                    <span className="text-slate-400">{challenge.participants}명</span>
+                    <span className="text-text-muted">{challenge.participants}명</span>
                   </div>
                   <div className="flex justify-between">
                     <span>기간</span>
-                    <span className="text-slate-400">{challenge.startDate} ~</span>
+                    <span className="text-text-muted">{challenge.startDate} ~</span>
                   </div>
                 </div>
               </div>
@@ -211,37 +211,37 @@ export const ChallengeList = () => {
         <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title="새 챌린지 생성">
           <form onSubmit={handleCreateChallenge} className="space-y-4">
             <div className="space-y-1">
-              <label className="text-sm font-medium text-slate-400">챌린지 제목</label>
+              <label className="text-sm font-medium text-text-muted">챌린지 제목</label>
               <input
                 type="text"
                 required
                 value={newChallenge.title}
                 onChange={(e) => setNewChallenge({ ...newChallenge, title: e.target.value })}
                 placeholder="예: 1일 1문제 뽀개기"
-                className="w-full bg-slate-900 border border-slate-800 rounded-lg px-4 py-2.5 text-slate-200 focus:outline-none focus:border-emerald-500"
+                className="w-full bg-input-bg border border-border-default rounded-lg px-4 py-2.5 text-text-secondary focus:outline-none focus:border-emerald-500"
               />
             </div>
 
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-1">
-                <label className="text-sm font-medium text-slate-400">기간 (일)</label>
+                <label className="text-sm font-medium text-text-muted">기간 (일)</label>
                 <div className="relative">
-                  <Timer className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+                  <Timer className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-faint" />
                   <input
                     type="number"
                     min="1"
                     value={newChallenge.duration}
                     onChange={(e) => setNewChallenge({ ...newChallenge, duration: e.target.value })}
-                    className="w-full bg-slate-900 border border-slate-800 rounded-lg pl-10 pr-4 py-2.5 text-slate-200 focus:outline-none focus:border-emerald-500"
+                    className="w-full bg-input-bg border border-border-default rounded-lg pl-10 pr-4 py-2.5 text-text-secondary focus:outline-none focus:border-emerald-500"
                   />
                 </div>
               </div>
               <div className="space-y-1">
-                <label className="text-sm font-medium text-slate-400">분류</label>
+                <label className="text-sm font-medium text-text-muted">분류</label>
                 <select
                   value={newChallenge.category}
                   onChange={(e) => setNewChallenge({ ...newChallenge, category: e.target.value })}
-                  className="w-full bg-slate-900 border border-slate-800 rounded-lg px-4 py-2.5 text-slate-200 focus:outline-none focus:border-emerald-500"
+                  className="w-full bg-input-bg border border-border-default rounded-lg px-4 py-2.5 text-text-secondary focus:outline-none focus:border-emerald-500"
                 >
                   <option>알고리즘</option>
                   <option>프로젝트</option>
@@ -251,23 +251,23 @@ export const ChallengeList = () => {
             </div>
 
             <div className="space-y-1">
-              <label className="text-sm font-medium text-slate-400">문제 선택</label>
-              <div className="border border-slate-800 rounded-lg bg-slate-900/50 p-3 h-32 overflow-y-auto space-y-2">
+              <label className="text-sm font-medium text-text-muted">문제 선택</label>
+              <div className="border border-border-default rounded-lg bg-input-bg/50 p-3 h-32 overflow-y-auto space-y-2">
                 {/* Mock Problem Selector */}
-                <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer p-1 hover:bg-slate-800 rounded">
-                  <input type="checkbox" className="rounded border-slate-700 bg-slate-800 text-emerald-500 focus:ring-emerald-500" />
+                <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer p-1 hover:bg-surface-subtle rounded">
+                  <input type="checkbox" className="rounded border-border-subtle bg-surface-subtle text-emerald-500 focus:ring-emerald-500" />
                   1000. A+B
                 </label>
-                <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer p-1 hover:bg-slate-800 rounded">
-                  <input type="checkbox" className="rounded border-slate-700 bg-slate-800 text-emerald-500 focus:ring-emerald-500" />
+                <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer p-1 hover:bg-surface-subtle rounded">
+                  <input type="checkbox" className="rounded border-border-subtle bg-surface-subtle text-emerald-500 focus:ring-emerald-500" />
                   1920. 수 찾기
                 </label>
-                <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer p-1 hover:bg-slate-800 rounded">
-                  <input type="checkbox" className="rounded border-slate-700 bg-slate-800 text-emerald-500 focus:ring-emerald-500" />
+                <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer p-1 hover:bg-surface-subtle rounded">
+                  <input type="checkbox" className="rounded border-border-subtle bg-surface-subtle text-emerald-500 focus:ring-emerald-500" />
                   2557. Hello World
                 </label>
-                <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer p-1 hover:bg-slate-800 rounded">
-                  <input type="checkbox" className="rounded border-slate-700 bg-slate-800 text-emerald-500 focus:ring-emerald-500" />
+                <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer p-1 hover:bg-surface-subtle rounded">
+                  <input type="checkbox" className="rounded border-border-subtle bg-surface-subtle text-emerald-500 focus:ring-emerald-500" />
                   2739. 구구단
                 </label>
               </div>

--- a/src/features/community/Community.tsx
+++ b/src/features/community/Community.tsx
@@ -95,13 +95,13 @@ export const Community = () => {
   };
 
   return (
-    <div className="flex-1 p-8 overflow-y-auto bg-[#0F1117] h-full">
+    <div className="flex-1 p-8 overflow-y-auto bg-page h-full">
       <div className="max-w-7xl mx-auto space-y-6">
         {/* Header */}
-        <div className="flex justify-between items-center border-b border-slate-800 pb-6">
+        <div className="flex justify-between items-center border-b border-border-default pb-6">
           <div>
-            <h1 className="text-3xl font-extrabold text-white tracking-tight mb-2">커뮤니티</h1>
-            <p className="text-slate-400 text-sm">팀원들과 자유롭게 이야기를 나누고 지식을 공유하세요.</p>
+            <h1 className="text-3xl font-extrabold text-text-primary tracking-tight mb-2">커뮤니티</h1>
+            <p className="text-text-muted text-sm">팀원들과 자유롭게 이야기를 나누고 지식을 공유하세요.</p>
           </div>
           <Button className="bg-emerald-600 hover:bg-emerald-700 gap-2 font-bold px-5" onClick={() => toWs('community/new')}>
             <PenSquare className="w-4 h-4" /> 새 게시물 작성
@@ -112,15 +112,15 @@ export const Community = () => {
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 py-2">
           {/* Tags */}
           <div className="flex items-center gap-3">
-            <Filter className="w-4 h-4 text-slate-500" />
-            <span className="text-sm font-medium text-slate-400 mr-2">태그 필터:</span>
+            <Filter className="w-4 h-4 text-text-faint" />
+            <span className="text-sm font-medium text-text-muted mr-2">태그 필터:</span>
             {filterTags.map(tag => (
               <button
                 key={tag}
                 onClick={() => handleTagChange(tag)}
                 className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-bold transition-all border ${selectedTag === tag
                   ? 'bg-emerald-500/20 text-emerald-400 border-emerald-500/50 shadow-sm'
-                  : 'bg-slate-800/50 text-slate-400 border-transparent hover:bg-slate-700 hover:text-slate-200'
+                  : 'bg-surface-subtle/50 text-text-muted border-transparent hover:bg-border-subtle hover:text-text-secondary'
                 }`}
               >
                 {selectedTag === tag && <Check className="w-3 h-3" />}
@@ -131,23 +131,23 @@ export const Community = () => {
 
           {/* Search Input */}
           <div className="relative w-full sm:w-64">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-faint" />
             <input
               type="text"
               placeholder="게시물 검색..."
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
               onKeyDown={handleSearchKeyDown}
-              className="w-full bg-slate-900 border border-slate-700 rounded-lg py-1.5 pl-9 pr-4 text-sm text-slate-200 focus:outline-none focus:border-emerald-500 transition-colors placeholder:text-slate-500"
+              className="w-full bg-input-bg border border-border-subtle rounded-lg py-1.5 pl-9 pr-4 text-sm text-text-secondary focus:outline-none focus:border-emerald-500 transition-colors placeholder:text-text-faint"
             />
           </div>
         </div>
 
         {/* Board Table */}
-        <div className="bg-[#141820] border border-slate-800 rounded-xl overflow-hidden shadow-sm">
+        <div className="bg-surface border border-border-default rounded-xl overflow-hidden shadow-sm">
           <table className="w-full text-left border-collapse">
             <thead>
-              <tr className="border-b border-slate-800 bg-[#151922] text-slate-400 text-xs uppercase tracking-wider">
+              <tr className="border-b border-border-default bg-surface-raised text-text-muted text-xs uppercase tracking-wider">
                 <th className="p-4 font-bold w-20 text-center">분류</th>
                 <th className="p-4 font-bold">제목</th>
                 <th className="p-4 font-bold w-32">작성자</th>
@@ -156,7 +156,7 @@ export const Community = () => {
                 <th className="p-4 font-bold w-20 text-center">추천</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-800/50 text-sm">
+            <tbody className="divide-y divide-border-default text-sm">
               {loading ? (
                 <tr>
                   <td colSpan={6} className="p-12 text-center">
@@ -165,7 +165,7 @@ export const Community = () => {
                 </tr>
               ) : posts.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="p-12 text-center text-slate-500">
+                  <td colSpan={6} className="p-12 text-center text-text-faint">
                     <MessageCircle className="w-8 h-8 mx-auto mb-3 opacity-20" />
                     게시글이 없습니다.
                   </td>
@@ -180,14 +180,14 @@ export const Community = () => {
                       className={`cursor-pointer group transition-colors ${
                         isNotice
                           ? 'bg-red-500/5 hover:bg-red-500/10'
-                          : 'hover:bg-slate-800/50'
+                          : 'hover:bg-hover-bg'
                       }`}
                     >
                       <td className="p-4 text-center">{getTagBadge(post.type, post.pinned)}</td>
                       <td className={`p-4 font-medium transition-colors ${
                         isNotice
-                          ? 'text-slate-100 group-hover:text-red-400'
-                          : 'text-slate-200 group-hover:text-emerald-400'
+                          ? 'text-text-primary group-hover:text-red-600 dark:group-hover:text-red-400'
+                          : 'text-text-secondary group-hover:text-emerald-600 dark:group-hover:text-emerald-400'
                       }`}>
                         {post.title}
                         {(post.commentCount ?? 0) > 0 && (
@@ -196,9 +196,9 @@ export const Community = () => {
                           </span>
                         )}
                       </td>
-                      <td className="p-4 text-slate-400">{post.author?.nickname}</td>
-                      <td className="p-4 text-center text-slate-500 font-mono text-xs">{formatDate(post.createdAt ?? '')}</td>
-                      <td className="p-4 text-center text-slate-500 font-mono">{post.viewCount}</td>
+                      <td className="p-4 text-text-muted">{post.author?.nickname}</td>
+                      <td className="p-4 text-center text-text-faint font-mono text-xs">{formatDate(post.createdAt ?? '')}</td>
+                      <td className="p-4 text-center text-text-faint font-mono">{post.viewCount}</td>
                       <td className="p-4 text-center text-emerald-500 font-bold font-mono">{post.likeCount}</td>
                     </tr>
                   );
@@ -211,12 +211,12 @@ export const Community = () => {
         {/* Pagination */}
         {totalPages > 1 && (
           <div className="flex items-center justify-between">
-            <span className="text-xs text-slate-500">총 {totalElements}개 게시물</span>
+            <span className="text-xs text-text-faint">총 {totalElements}개 게시물</span>
             <div className="flex items-center gap-1">
               <button
                 onClick={() => setPage(p => Math.max(0, p - 1))}
                 disabled={page === 0}
-                className="p-2 text-slate-400 hover:text-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                className="p-2 text-text-muted hover:text-text-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
               >
                 <ChevronLeft className="w-4 h-4" />
               </button>
@@ -227,7 +227,7 @@ export const Community = () => {
                   className={`w-8 h-8 rounded-lg text-xs font-bold transition-colors ${
                     page === i
                       ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/50'
-                      : 'text-slate-500 hover:bg-slate-800 hover:text-slate-300'
+                      : 'text-text-faint hover:bg-surface-subtle hover:text-text-secondary'
                   }`}
                 >
                   {i + 1}
@@ -236,7 +236,7 @@ export const Community = () => {
               <button
                 onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
                 disabled={page >= totalPages - 1}
-                className="p-2 text-slate-400 hover:text-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                className="p-2 text-text-muted hover:text-text-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
               >
                 <ChevronRight className="w-4 h-4" />
               </button>

--- a/src/features/community/PostCreate.tsx
+++ b/src/features/community/PostCreate.tsx
@@ -196,30 +196,30 @@ export const PostCreate = () => {
   const charOver = charCount > 2000;
 
   return (
-    <div className="flex-1 p-8 overflow-y-auto bg-[#0F1117] h-full">
+    <div className="flex-1 p-8 overflow-y-auto bg-page h-full">
       <div className="max-w-4xl mx-auto space-y-6">
 
         {/* Header */}
-        <div className="flex items-center gap-4 border-b border-slate-800 pb-6">
+        <div className="flex items-center gap-4 border-b border-border-default pb-6">
           <button
             onClick={() => toWs('community')}
-            className="p-2 text-slate-400 hover:text-slate-200 hover:bg-slate-800 rounded-full transition-colors focus:outline-none"
+            className="p-2 text-text-muted hover:text-text-secondary hover:bg-surface-subtle rounded-full transition-colors focus:outline-none"
           >
             <ArrowLeft className="w-5 h-5" />
           </button>
           <div>
-            <h1 className="text-2xl font-extrabold text-white tracking-tight">새 게시물 작성</h1>
-            <p className="text-slate-400 text-sm mt-1">마크다운 문법을 지원합니다. 팀원들에게 유용한 정보를 공유하거나 질문해보세요.</p>
+            <h1 className="text-2xl font-extrabold text-text-primary tracking-tight">새 게시물 작성</h1>
+            <p className="text-text-muted text-sm mt-1">마크다운 문법을 지원합니다. 팀원들에게 유용한 정보를 공유하거나 질문해보세요.</p>
           </div>
         </div>
 
         {/* Editor Form */}
-        <Card className="bg-[#141820] border-slate-800 p-6 shadow-sm">
+        <Card className="bg-surface border-border-default p-6 shadow-sm">
           <form onSubmit={handleSubmit} className="space-y-6">
 
             {/* Tag Selection */}
             <div>
-              <label className="block text-sm font-bold text-slate-300 mb-3">태그 분류</label>
+              <label className="block text-sm font-bold text-text-secondary mb-3">태그 분류</label>
               <div className="flex gap-2">
                 {availableTags.map(tag => (
                   <button
@@ -228,7 +228,7 @@ export const PostCreate = () => {
                     onClick={() => setSelectedTag(tag)}
                     className={`flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-bold transition-all border ${selectedTag === tag
                       ? 'bg-emerald-500/20 text-emerald-400 border-emerald-500/50 shadow-sm'
-                      : 'bg-slate-900 text-slate-400 border-slate-800 hover:bg-slate-800 hover:text-slate-200'
+                      : 'bg-input-bg text-text-muted border-border-default hover:bg-surface-subtle hover:text-text-secondary'
                     }`}
                   >
                     {selectedTag === tag && <Check className="w-3.5 h-3.5" />}
@@ -244,7 +244,7 @@ export const PostCreate = () => {
                   className={`mt-3 inline-flex items-center gap-2.5 px-4 py-2 rounded-lg text-sm font-medium transition-all border ${
                     pinned
                       ? 'bg-yellow-500/10 text-yellow-400 border-yellow-500/30'
-                      : 'bg-slate-900 text-slate-400 border-slate-800 hover:bg-slate-800 hover:text-slate-300'
+                      : 'bg-input-bg text-text-muted border-border-default hover:bg-surface-subtle hover:text-text-secondary'
                   }`}
                 >
                   {pinned ? <Pin className="w-3.5 h-3.5" /> : <PinOff className="w-3.5 h-3.5" />}
@@ -261,20 +261,20 @@ export const PostCreate = () => {
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="게시물 제목을 입력하세요"
                 maxLength={50}
-                className="w-full bg-transparent border-0 border-b border-slate-800 focus:outline-none focus:ring-0 text-2xl font-bold text-slate-100 placeholder:text-slate-600 focus:border-emerald-500/50 transition-colors pb-3"
+                className="w-full bg-transparent border-0 border-b border-border-default focus:outline-none focus:ring-0 text-2xl font-bold text-text-primary placeholder:text-text-faint focus:border-emerald-500/50 transition-colors pb-3"
                 autoFocus
               />
               <div className="flex justify-end mt-1">
-                <span className={`text-xs font-mono ${title.length > 50 ? 'text-red-400' : 'text-slate-600'}`}>
+                <span className={`text-xs font-mono ${title.length > 50 ? 'text-red-400' : 'text-text-faint'}`}>
                   {title.length}/50
                 </span>
               </div>
             </div>
 
             {/* Markdown Editor */}
-            <div className="border border-slate-800 rounded-xl overflow-hidden">
+            <div className="border border-border-default rounded-xl overflow-hidden">
               {/* Editor Tabs */}
-              <div className="flex items-center justify-between bg-[#0F1117] border-b border-slate-800 px-4">
+              <div className="flex items-center justify-between bg-page border-b border-border-default px-4">
                 <div className="flex">
                   <button
                     type="button"
@@ -282,7 +282,7 @@ export const PostCreate = () => {
                     className={`flex items-center gap-2 px-4 py-3 text-sm font-bold transition-colors border-b-2 ${
                       activeTab === 'write'
                         ? 'text-emerald-400 border-emerald-500'
-                        : 'text-slate-500 border-transparent hover:text-slate-300'
+                        : 'text-text-faint border-transparent hover:text-text-secondary'
                     }`}
                   >
                     <Edit3 className="w-4 h-4" />
@@ -294,28 +294,28 @@ export const PostCreate = () => {
                     className={`flex items-center gap-2 px-4 py-3 text-sm font-bold transition-colors border-b-2 ${
                       activeTab === 'preview'
                         ? 'text-emerald-400 border-emerald-500'
-                        : 'text-slate-500 border-transparent hover:text-slate-300'
+                        : 'text-text-faint border-transparent hover:text-text-secondary'
                     }`}
                   >
                     <Eye className="w-4 h-4" />
                     미리보기
                   </button>
                 </div>
-                <span className={`text-xs font-mono ${charOver ? 'text-red-400' : 'text-slate-600'}`}>
+                <span className={`text-xs font-mono ${charOver ? 'text-red-400' : 'text-text-faint'}`}>
                   {charCount}/2000
                 </span>
               </div>
 
               {/* Toolbar (작성 탭에서만) */}
               {activeTab === 'write' && (
-                <div className="flex items-center gap-1 px-3 py-2 bg-[#0F1117]/50 border-b border-slate-800/50 flex-wrap">
+                <div className="flex items-center gap-1 px-3 py-2 bg-page/50 border-b border-border-default/50 flex-wrap">
                   {TOOLBAR_ACTIONS.map((action, i) => (
                     <button
                       key={i}
                       type="button"
                       onClick={() => handleToolbarAction(action)}
                       title={action.label}
-                      className="p-1.5 text-slate-500 hover:text-slate-200 hover:bg-slate-800 rounded transition-colors"
+                      className="p-1.5 text-text-faint hover:text-text-secondary hover:bg-surface-subtle rounded transition-colors"
                     >
                       <action.icon className="w-4 h-4" />
                     </button>
@@ -331,32 +331,32 @@ export const PostCreate = () => {
                   onChange={(e) => setContent(e.target.value)}
                   onPaste={handlePaste}
                   placeholder="마크다운으로 작성해보세요...&#10;&#10;# 제목&#10;## 소제목&#10;**굵게** *기울임* `코드`&#10;- 목록 항목&#10;```python&#10;print('Hello!')&#10;```&#10;&#10;이미지 URL 붙여넣기 시 자동 변환됩니다."
-                  className="w-full min-h-[400px] bg-slate-900/30 p-5 text-slate-200 text-sm font-mono placeholder:text-slate-600 focus:outline-none resize-y leading-relaxed"
+                  className="w-full min-h-[400px] bg-input-bg/30 p-5 text-text-secondary text-sm font-mono placeholder:text-text-faint focus:outline-none resize-y leading-relaxed"
                 />
               ) : (
-                <div className="min-h-[400px] p-5 bg-slate-900/30">
+                <div className="min-h-[400px] p-5 bg-input-bg/30">
                   {content.trim() ? (
-                    <div className="prose prose-invert max-w-none
-                      prose-headings:text-slate-100 prose-headings:font-bold prose-headings:tracking-tight
+                    <div className="prose dark:prose-invert max-w-none
+                      prose-headings:text-text-primary prose-headings:font-bold prose-headings:tracking-tight
                       prose-h1:text-2xl prose-h1:mt-8 prose-h1:mb-4
                       prose-h2:text-xl prose-h2:mt-7 prose-h2:mb-3
                       prose-h3:text-lg prose-h3:mt-6 prose-h3:mb-2
-                      prose-p:text-[15px] prose-p:text-slate-300 prose-p:leading-[1.8] prose-p:my-3
-                      prose-a:text-emerald-400 prose-a:no-underline hover:prose-a:underline
-                      prose-strong:text-slate-100 prose-strong:font-bold
-                      prose-code:text-emerald-300 prose-code:bg-slate-800/80 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:text-[13px] prose-code:before:content-none prose-code:after:content-none
-                      prose-pre:bg-[#0D1017] prose-pre:border prose-pre:border-slate-700/50 prose-pre:rounded-xl prose-pre:my-4
-                      prose-blockquote:border-l-emerald-500/40 prose-blockquote:bg-emerald-500/5 prose-blockquote:rounded-r-lg prose-blockquote:py-1 prose-blockquote:px-4 prose-blockquote:text-slate-400 prose-blockquote:not-italic
+                      prose-p:text-[15px] prose-p:text-text-secondary prose-p:leading-[1.8] prose-p:my-3
+                      prose-a:text-emerald-600 dark:prose-a:text-emerald-400 prose-a:no-underline hover:prose-a:underline
+                      prose-strong:text-text-primary prose-strong:font-bold
+                      prose-code:text-emerald-600 dark:prose-code:text-emerald-300 prose-code:bg-surface-subtle/80 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:text-[13px] prose-code:before:content-none prose-code:after:content-none
+                      prose-pre:bg-page-deep prose-pre:border prose-pre:border-border-subtle/50 prose-pre:rounded-xl prose-pre:my-4
+                      prose-blockquote:border-l-emerald-500/40 prose-blockquote:bg-emerald-500/5 prose-blockquote:rounded-r-lg prose-blockquote:py-1 prose-blockquote:px-4 prose-blockquote:text-text-muted prose-blockquote:not-italic
                       prose-ul:my-3 prose-ol:my-3
-                      prose-li:text-[15px] prose-li:text-slate-300 prose-li:leading-[1.8] prose-li:my-0.5
-                      prose-hr:border-slate-700/50 prose-hr:my-6
+                      prose-li:text-[15px] prose-li:text-text-secondary prose-li:leading-[1.8] prose-li:my-0.5
+                      prose-hr:border-border-subtle/50 prose-hr:my-6
                       prose-img:rounded-xl
-                      prose-th:text-slate-300 prose-td:text-slate-400
+                      prose-th:text-text-secondary prose-td:text-text-muted
                     ">
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
                     </div>
                   ) : (
-                    <p className="text-slate-600 text-sm">미리볼 내용이 없습니다. 작성 탭에서 마크다운을 입력해주세요.</p>
+                    <p className="text-text-faint text-sm">미리볼 내용이 없습니다. 작성 탭에서 마크다운을 입력해주세요.</p>
                   )}
                 </div>
               )}
@@ -370,12 +370,12 @@ export const PostCreate = () => {
             )}
 
             {/* Action Buttons */}
-            <div className="flex justify-end gap-3 pt-4 border-t border-slate-800">
+            <div className="flex justify-end gap-3 pt-4 border-t border-border-default">
               <Button
                 type="button"
                 variant="outline"
                 onClick={() => toWs('community')}
-                className="border-slate-700 text-slate-300 hover:bg-slate-800 hover:text-white"
+                className="border-border-subtle text-text-secondary hover:bg-surface-subtle hover:text-text-primary"
               >
                 취소
               </Button>

--- a/src/features/community/PostDetail.tsx
+++ b/src/features/community/PostDetail.tsx
@@ -182,7 +182,7 @@ export const PostDetail = () => {
 
   if (loading) {
     return (
-      <div className="flex-1 flex items-center justify-center bg-[#0F1117] h-full">
+      <div className="flex-1 flex items-center justify-center bg-page h-full">
         <Loader2 className="w-8 h-8 text-emerald-500 animate-spin" />
       </div>
     );
@@ -190,10 +190,10 @@ export const PostDetail = () => {
 
   if (error || !post) {
     return (
-      <div className="flex-1 p-8 bg-[#0F1117] h-full">
+      <div className="flex-1 p-8 bg-page h-full">
         <div className="max-w-4xl mx-auto text-center py-20">
-          <p className="text-slate-400 text-lg mb-4">{error || '게시물을 찾을 수 없습니다.'}</p>
-          <Button variant="outline" onClick={() => toWs('community')} className="border-slate-700 text-slate-300">
+          <p className="text-text-muted text-lg mb-4">{error || '게시물을 찾을 수 없습니다.'}</p>
+          <Button variant="outline" onClick={() => toWs('community')} className="border-border-subtle text-text-secondary">
             <ArrowLeft className="w-4 h-4 mr-2" /> 목록으로
           </Button>
         </div>
@@ -202,19 +202,19 @@ export const PostDetail = () => {
   }
 
   return (
-    <div className="flex-1 p-8 overflow-y-auto bg-[#0F1117] h-full">
+    <div className="flex-1 p-8 overflow-y-auto bg-page h-full">
       <div className="max-w-4xl mx-auto space-y-5">
 
         {/* Back */}
         <button
           onClick={() => toWs('community')}
-          className="flex items-center gap-2 text-slate-400 hover:text-slate-200 transition-colors text-sm"
+          className="flex items-center gap-2 text-text-muted hover:text-text-secondary transition-colors text-sm"
         >
           <ArrowLeft className="w-4 h-4" /> 목록으로
         </button>
 
         {/* ─── 게시물 본문 카드 ─── */}
-        <Card className="bg-[#141820] border-slate-800 shadow-sm overflow-hidden">
+        <Card className="bg-surface border-border-default shadow-sm overflow-hidden">
 
           {/* Header 영역 */}
           <div className="px-7 pt-6 pb-5 space-y-3">
@@ -241,7 +241,7 @@ export const PostDetail = () => {
                   {isAuthor && (
                     <button
                       onClick={() => toWs(`community/${numericBoardId}/edit`)}
-                      className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
+                      className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium text-text-muted hover:text-text-secondary hover:bg-surface-subtle transition-colors"
                     >
                       <Edit3 className="w-3.5 h-3.5" /> 수정
                     </button>
@@ -257,14 +257,14 @@ export const PostDetail = () => {
             </div>
 
             {/* 제목 */}
-            <h1 className="text-[1.6rem] font-extrabold text-white leading-snug tracking-tight">
+            <h1 className="text-[1.6rem] font-extrabold text-text-primary leading-snug tracking-tight">
               {post.title}
             </h1>
 
             {/* 메타 정보 */}
-            <div className="flex items-center gap-4 text-[13px] text-slate-500">
-              <span className="flex items-center gap-1.5 font-medium text-slate-300">
-                <User className="w-3.5 h-3.5 text-slate-500" /> {post.author?.nickname}
+            <div className="flex items-center gap-4 text-[13px] text-text-faint">
+              <span className="flex items-center gap-1.5 font-medium text-text-secondary">
+                <User className="w-3.5 h-3.5 text-text-faint" /> {post.author?.nickname}
               </span>
               <span className="flex items-center gap-1.5">
                 <Clock className="w-3.5 h-3.5" /> {formatDate(post.createdAt ?? '')}
@@ -279,57 +279,57 @@ export const PostDetail = () => {
           </div>
 
           {/* 구분선 */}
-          <div className="border-t border-slate-800" />
+          <div className="border-t border-border-default" />
 
           {/* 본문 마크다운 */}
           <div className="px-7 pt-4 pb-6">
-            <div className="prose prose-invert max-w-none
-              prose-headings:text-slate-100 prose-headings:font-bold prose-headings:tracking-tight
+            <div className="prose dark:prose-invert max-w-none
+              prose-headings:text-text-primary prose-headings:font-bold prose-headings:tracking-tight
               prose-h1:text-2xl prose-h1:mt-8 prose-h1:mb-4
               prose-h2:text-xl prose-h2:mt-7 prose-h2:mb-3
               prose-h3:text-lg prose-h3:mt-6 prose-h3:mb-2
-              prose-p:text-[15px] prose-p:text-slate-300 prose-p:leading-[1.8] prose-p:my-3
-              prose-a:text-emerald-400 prose-a:no-underline hover:prose-a:underline
-              prose-strong:text-slate-100 prose-strong:font-bold
-              prose-em:text-slate-300
-              prose-code:text-emerald-300 prose-code:bg-slate-800/80 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:text-[13px] prose-code:font-normal prose-code:before:content-none prose-code:after:content-none
-              prose-pre:bg-[#0D1017] prose-pre:border prose-pre:border-slate-700/50 prose-pre:rounded-xl prose-pre:my-4
-              prose-blockquote:border-l-emerald-500/40 prose-blockquote:bg-emerald-500/5 prose-blockquote:rounded-r-lg prose-blockquote:py-1 prose-blockquote:px-4 prose-blockquote:text-slate-400 prose-blockquote:not-italic
+              prose-p:text-[15px] prose-p:text-text-secondary prose-p:leading-[1.8] prose-p:my-3
+              prose-a:text-emerald-600 dark:prose-a:text-emerald-400 prose-a:no-underline hover:prose-a:underline
+              prose-strong:text-text-primary prose-strong:font-bold
+              prose-em:text-text-secondary
+              prose-code:text-emerald-600 dark:prose-code:text-emerald-300 prose-code:bg-surface-subtle/80 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:text-[13px] prose-code:font-normal prose-code:before:content-none prose-code:after:content-none
+              prose-pre:bg-page-deep prose-pre:border prose-pre:border-border-subtle/50 prose-pre:rounded-xl prose-pre:my-4
+              prose-blockquote:border-l-emerald-500/40 prose-blockquote:bg-emerald-500/5 prose-blockquote:rounded-r-lg prose-blockquote:py-1 prose-blockquote:px-4 prose-blockquote:text-text-muted prose-blockquote:not-italic
               prose-ul:my-3 prose-ol:my-3
-              prose-li:text-[15px] prose-li:text-slate-300 prose-li:leading-[1.8] prose-li:my-0.5
-              prose-hr:border-slate-700/50 prose-hr:my-6
-              prose-img:rounded-xl prose-img:border prose-img:border-slate-800
+              prose-li:text-[15px] prose-li:text-text-secondary prose-li:leading-[1.8] prose-li:my-0.5
+              prose-hr:border-border-subtle/50 prose-hr:my-6
+              prose-img:rounded-xl prose-img:border prose-img:border-border-default
               prose-table:text-sm
-              prose-th:text-slate-300 prose-th:bg-slate-800/50 prose-th:px-3 prose-th:py-2
-              prose-td:text-slate-400 prose-td:px-3 prose-td:py-2 prose-td:border-slate-700/50
+              prose-th:text-text-secondary prose-th:bg-surface-subtle/50 prose-th:px-3 prose-th:py-2
+              prose-td:text-text-muted prose-td:px-3 prose-td:py-2 prose-td:border-border-subtle/50
             ">
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{post.content ?? ''}</ReactMarkdown>
             </div>
           </div>
 
           {/* 추천 바 — 본문 카드 하단에 자연스럽게 */}
-          <div className="border-t border-slate-800 px-7 py-4 flex items-center justify-between">
+          <div className="border-t border-border-default px-7 py-4 flex items-center justify-between">
             <button
               onClick={handleLikeToggle}
               className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
                 post.myLike
                   ? 'bg-emerald-500/15 text-emerald-400 hover:bg-emerald-500/25'
-                  : 'text-slate-400 hover:bg-slate-800 hover:text-slate-200'
+                  : 'text-text-muted hover:bg-surface-subtle hover:text-text-secondary'
               }`}
             >
               <ThumbsUp className={`w-[18px] h-[18px] ${post.myLike ? 'fill-emerald-400' : ''}`} />
               추천 {(post.likeCount ?? 0) > 0 && <span className="tabular-nums">{post.likeCount}</span>}
             </button>
-            <span className="text-xs text-slate-600">
+            <span className="text-xs text-text-faint">
               {post.updatedAt !== post.createdAt && `수정됨 ${formatDate(post.updatedAt ?? '')}`}
             </span>
           </div>
         </Card>
 
         {/* ─── 댓글 섹션 ─── */}
-        <Card className="bg-[#141820] border-slate-800 shadow-sm overflow-hidden">
+        <Card className="bg-surface border-border-default shadow-sm overflow-hidden">
           <div className="px-7 py-5">
-            <h3 className="text-[15px] font-bold text-white flex items-center gap-2 mb-5">
+            <h3 className="text-[15px] font-bold text-text-primary flex items-center gap-2 mb-5">
               <MessageCircle className="w-[18px] h-[18px] text-emerald-500" />
               댓글 <span className="text-emerald-500 tabular-nums">{post.commentCount}</span>
             </h3>
@@ -343,7 +343,7 @@ export const PostDetail = () => {
                 onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleCommentSubmit(); } }}
                 placeholder="댓글을 입력하세요..."
                 maxLength={255}
-                className="flex-1 bg-slate-900/80 border border-slate-700/50 rounded-lg py-2.5 px-4 text-sm text-slate-200 focus:outline-none focus:border-emerald-500/50 transition-colors placeholder:text-slate-600"
+                className="flex-1 bg-input-bg/80 border border-border-subtle/50 rounded-lg py-2.5 px-4 text-sm text-text-secondary focus:outline-none focus:border-emerald-500/50 transition-colors placeholder:text-text-faint"
               />
               <Button
                 onClick={handleCommentSubmit}
@@ -355,9 +355,9 @@ export const PostDetail = () => {
             </div>
 
             {/* 댓글 목록 */}
-            <div className="divide-y divide-slate-800/40">
+            <div className="divide-y divide-border-default">
               {comments.length === 0 ? (
-                <p className="text-slate-600 text-sm py-8 text-center">아직 댓글이 없습니다. 첫 댓글을 남겨보세요!</p>
+                <p className="text-text-faint text-sm py-8 text-center">아직 댓글이 없습니다. 첫 댓글을 남겨보세요!</p>
               ) : (
                 comments.map(c => {
                   const isCommentAuthor = myMemberId !== null && c.author?.workspaceMemberId === myMemberId;
@@ -367,16 +367,16 @@ export const PostDetail = () => {
                       <div className="flex items-start justify-between gap-3">
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2.5 mb-1.5">
-                            <span className="text-[13px] font-bold text-slate-200">{c.author?.nickname}</span>
-                            <span className="text-[11px] text-slate-600 tabular-nums">{formatDate(c.createdAt ?? '')}</span>
+                            <span className="text-[13px] font-bold text-text-secondary">{c.author?.nickname}</span>
+                            <span className="text-[11px] text-text-faint tabular-nums">{formatDate(c.createdAt ?? '')}</span>
                           </div>
-                          <p className="text-[14px] text-slate-300 leading-relaxed whitespace-pre-wrap break-words">{c.content}</p>
+                          <p className="text-[14px] text-text-secondary leading-relaxed whitespace-pre-wrap break-words">{c.content}</p>
                         </div>
                         {canDeleteComment && (
                           <button
                             onClick={() => handleCommentDelete(c.boardCommentId!)}
 
-                            className="p-1.5 text-slate-700 hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100 shrink-0"
+                            className="p-1.5 text-text-faint hover:text-red-600 dark:hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100 shrink-0"
                             title="삭제"
                           >
                             <Trash2 className="w-3.5 h-3.5" />
@@ -391,7 +391,7 @@ export const PostDetail = () => {
 
             {/* 댓글 페이지네이션 */}
             {commentTotalPages > 1 && (
-              <div className="flex justify-center gap-1.5 pt-4 mt-2 border-t border-slate-800/40">
+              <div className="flex justify-center gap-1.5 pt-4 mt-2 border-t border-border-default/40">
                 {Array.from({ length: commentTotalPages }, (_, i) => (
                   <button
                     key={i}
@@ -399,7 +399,7 @@ export const PostDetail = () => {
                     className={`w-7 h-7 rounded-md text-xs font-bold transition-colors ${
                       commentPage === i
                         ? 'bg-emerald-500/20 text-emerald-400'
-                        : 'text-slate-600 hover:bg-slate-800 hover:text-slate-400'
+                        : 'text-text-faint hover:bg-surface-subtle hover:text-text-muted'
                     }`}
                   >
                     {i + 1}

--- a/src/features/community/PostEdit.tsx
+++ b/src/features/community/PostEdit.tsx
@@ -220,37 +220,37 @@ export const PostEdit = () => {
 
   if (loading) {
     return (
-      <div className="flex-1 flex items-center justify-center bg-[#0F1117] h-full">
+      <div className="flex-1 flex items-center justify-center bg-page h-full">
         <Loader2 className="w-8 h-8 text-emerald-500 animate-spin" />
       </div>
     );
   }
 
   return (
-    <div className="flex-1 p-8 overflow-y-auto bg-[#0F1117] h-full">
+    <div className="flex-1 p-8 overflow-y-auto bg-page h-full">
       <div className="max-w-4xl mx-auto space-y-6">
 
         {/* Header */}
-        <div className="flex items-center gap-4 border-b border-slate-800 pb-6">
+        <div className="flex items-center gap-4 border-b border-border-default pb-6">
           <button
             onClick={() => toWs(`community/${numericBoardId}`)}
-            className="p-2 text-slate-400 hover:text-slate-200 hover:bg-slate-800 rounded-full transition-colors focus:outline-none"
+            className="p-2 text-text-muted hover:text-text-secondary hover:bg-surface-subtle rounded-full transition-colors focus:outline-none"
           >
             <ArrowLeft className="w-5 h-5" />
           </button>
           <div>
-            <h1 className="text-2xl font-extrabold text-white tracking-tight">게시물 수정</h1>
-            <p className="text-slate-400 text-sm mt-1">마크다운 문법을 지원합니다.</p>
+            <h1 className="text-2xl font-extrabold text-text-primary tracking-tight">게시물 수정</h1>
+            <p className="text-text-muted text-sm mt-1">마크다운 문법을 지원합니다.</p>
           </div>
         </div>
 
         {/* Editor Form */}
-        <Card className="bg-[#141820] border-slate-800 p-6 shadow-sm">
+        <Card className="bg-surface border-border-default p-6 shadow-sm">
           <form onSubmit={handleSubmit} className="space-y-6">
 
             {/* Tag Selection */}
             <div>
-              <label className="block text-sm font-bold text-slate-300 mb-3">태그 분류</label>
+              <label className="block text-sm font-bold text-text-secondary mb-3">태그 분류</label>
               <div className="flex gap-2">
                 {availableTags.map(tag => (
                   <button
@@ -259,7 +259,7 @@ export const PostEdit = () => {
                     onClick={() => setSelectedTag(tag)}
                     className={`flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-bold transition-all border ${selectedTag === tag
                       ? 'bg-emerald-500/20 text-emerald-400 border-emerald-500/50 shadow-sm'
-                      : 'bg-slate-900 text-slate-400 border-slate-800 hover:bg-slate-800 hover:text-slate-200'
+                      : 'bg-input-bg text-text-muted border-border-default hover:bg-surface-subtle hover:text-text-secondary'
                     }`}
                   >
                     {selectedTag === tag && <Check className="w-3.5 h-3.5" />}
@@ -275,7 +275,7 @@ export const PostEdit = () => {
                   className={`mt-3 inline-flex items-center gap-2.5 px-4 py-2 rounded-lg text-sm font-medium transition-all border ${
                     pinned
                       ? 'bg-yellow-500/10 text-yellow-400 border-yellow-500/30'
-                      : 'bg-slate-900 text-slate-400 border-slate-800 hover:bg-slate-800 hover:text-slate-300'
+                      : 'bg-input-bg text-text-muted border-border-default hover:bg-surface-subtle hover:text-text-secondary'
                   }`}
                 >
                   {pinned ? <Pin className="w-3.5 h-3.5" /> : <PinOff className="w-3.5 h-3.5" />}
@@ -292,20 +292,20 @@ export const PostEdit = () => {
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="게시물 제목을 입력하세요"
                 maxLength={50}
-                className="w-full bg-transparent border-0 border-b border-slate-800 focus:outline-none focus:ring-0 text-2xl font-bold text-slate-100 placeholder:text-slate-600 focus:border-emerald-500/50 transition-colors pb-3"
+                className="w-full bg-transparent border-0 border-b border-border-default focus:outline-none focus:ring-0 text-2xl font-bold text-text-primary placeholder:text-text-faint focus:border-emerald-500/50 transition-colors pb-3"
                 autoFocus
               />
               <div className="flex justify-end mt-1">
-                <span className={`text-xs font-mono ${title.length > 50 ? 'text-red-400' : 'text-slate-600'}`}>
+                <span className={`text-xs font-mono ${title.length > 50 ? 'text-red-400' : 'text-text-faint'}`}>
                   {title.length}/50
                 </span>
               </div>
             </div>
 
             {/* Markdown Editor */}
-            <div className="border border-slate-800 rounded-xl overflow-hidden">
+            <div className="border border-border-default rounded-xl overflow-hidden">
               {/* Editor Tabs */}
-              <div className="flex items-center justify-between bg-[#0F1117] border-b border-slate-800 px-4">
+              <div className="flex items-center justify-between bg-page border-b border-border-default px-4">
                 <div className="flex">
                   <button
                     type="button"
@@ -313,7 +313,7 @@ export const PostEdit = () => {
                     className={`flex items-center gap-2 px-4 py-3 text-sm font-bold transition-colors border-b-2 ${
                       activeTab === 'write'
                         ? 'text-emerald-400 border-emerald-500'
-                        : 'text-slate-500 border-transparent hover:text-slate-300'
+                        : 'text-text-faint border-transparent hover:text-text-secondary'
                     }`}
                   >
                     <Edit3 className="w-4 h-4" />
@@ -325,28 +325,28 @@ export const PostEdit = () => {
                     className={`flex items-center gap-2 px-4 py-3 text-sm font-bold transition-colors border-b-2 ${
                       activeTab === 'preview'
                         ? 'text-emerald-400 border-emerald-500'
-                        : 'text-slate-500 border-transparent hover:text-slate-300'
+                        : 'text-text-faint border-transparent hover:text-text-secondary'
                     }`}
                   >
                     <Eye className="w-4 h-4" />
                     미리보기
                   </button>
                 </div>
-                <span className={`text-xs font-mono ${charOver ? 'text-red-400' : 'text-slate-600'}`}>
+                <span className={`text-xs font-mono ${charOver ? 'text-red-400' : 'text-text-faint'}`}>
                   {charCount}/2000
                 </span>
               </div>
 
               {/* Toolbar (작성 탭에서만) */}
               {activeTab === 'write' && (
-                <div className="flex items-center gap-1 px-3 py-2 bg-[#0F1117]/50 border-b border-slate-800/50 flex-wrap">
+                <div className="flex items-center gap-1 px-3 py-2 bg-page/50 border-b border-border-default/50 flex-wrap">
                   {TOOLBAR_ACTIONS.map((action, i) => (
                     <button
                       key={i}
                       type="button"
                       onClick={() => handleToolbarAction(action)}
                       title={action.label}
-                      className="p-1.5 text-slate-500 hover:text-slate-200 hover:bg-slate-800 rounded transition-colors"
+                      className="p-1.5 text-text-faint hover:text-text-secondary hover:bg-surface-subtle rounded transition-colors"
                     >
                       <action.icon className="w-4 h-4" />
                     </button>
@@ -362,32 +362,32 @@ export const PostEdit = () => {
                   onChange={(e) => setContent(e.target.value)}
                   onPaste={handlePaste}
                   placeholder="마크다운으로 작성해보세요..."
-                  className="w-full min-h-[400px] bg-slate-900/30 p-5 text-slate-200 text-sm font-mono placeholder:text-slate-600 focus:outline-none resize-y leading-relaxed"
+                  className="w-full min-h-[400px] bg-input-bg/30 p-5 text-text-secondary text-sm font-mono placeholder:text-text-faint focus:outline-none resize-y leading-relaxed"
                 />
               ) : (
-                <div className="min-h-[400px] p-5 bg-slate-900/30">
+                <div className="min-h-[400px] p-5 bg-input-bg/30">
                   {content.trim() ? (
-                    <div className="prose prose-invert max-w-none
-                      prose-headings:text-slate-100 prose-headings:font-bold prose-headings:tracking-tight
+                    <div className="prose dark:prose-invert max-w-none
+                      prose-headings:text-text-primary prose-headings:font-bold prose-headings:tracking-tight
                       prose-h1:text-2xl prose-h1:mt-8 prose-h1:mb-4
                       prose-h2:text-xl prose-h2:mt-7 prose-h2:mb-3
                       prose-h3:text-lg prose-h3:mt-6 prose-h3:mb-2
-                      prose-p:text-[15px] prose-p:text-slate-300 prose-p:leading-[1.8] prose-p:my-3
-                      prose-a:text-emerald-400 prose-a:no-underline hover:prose-a:underline
-                      prose-strong:text-slate-100 prose-strong:font-bold
-                      prose-code:text-emerald-300 prose-code:bg-slate-800/80 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:text-[13px] prose-code:before:content-none prose-code:after:content-none
-                      prose-pre:bg-[#0D1017] prose-pre:border prose-pre:border-slate-700/50 prose-pre:rounded-xl prose-pre:my-4
-                      prose-blockquote:border-l-emerald-500/40 prose-blockquote:bg-emerald-500/5 prose-blockquote:rounded-r-lg prose-blockquote:py-1 prose-blockquote:px-4 prose-blockquote:text-slate-400 prose-blockquote:not-italic
+                      prose-p:text-[15px] prose-p:text-text-secondary prose-p:leading-[1.8] prose-p:my-3
+                      prose-a:text-emerald-600 dark:prose-a:text-emerald-400 prose-a:no-underline hover:prose-a:underline
+                      prose-strong:text-text-primary prose-strong:font-bold
+                      prose-code:text-emerald-600 dark:prose-code:text-emerald-300 prose-code:bg-surface-subtle/80 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:text-[13px] prose-code:before:content-none prose-code:after:content-none
+                      prose-pre:bg-page-deep prose-pre:border prose-pre:border-border-subtle/50 prose-pre:rounded-xl prose-pre:my-4
+                      prose-blockquote:border-l-emerald-500/40 prose-blockquote:bg-emerald-500/5 prose-blockquote:rounded-r-lg prose-blockquote:py-1 prose-blockquote:px-4 prose-blockquote:text-text-muted prose-blockquote:not-italic
                       prose-ul:my-3 prose-ol:my-3
-                      prose-li:text-[15px] prose-li:text-slate-300 prose-li:leading-[1.8] prose-li:my-0.5
-                      prose-hr:border-slate-700/50 prose-hr:my-6
+                      prose-li:text-[15px] prose-li:text-text-secondary prose-li:leading-[1.8] prose-li:my-0.5
+                      prose-hr:border-border-subtle/50 prose-hr:my-6
                       prose-img:rounded-xl
-                      prose-th:text-slate-300 prose-td:text-slate-400
+                      prose-th:text-text-secondary prose-td:text-text-muted
                     ">
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
                     </div>
                   ) : (
-                    <p className="text-slate-600 text-sm">미리볼 내용이 없습니다. 작성 탭에서 마크다운을 입력해주세요.</p>
+                    <p className="text-text-faint text-sm">미리볼 내용이 없습니다. 작성 탭에서 마크다운을 입력해주세요.</p>
                   )}
                 </div>
               )}
@@ -401,12 +401,12 @@ export const PostEdit = () => {
             )}
 
             {/* Action Buttons */}
-            <div className="flex justify-end gap-3 pt-4 border-t border-slate-800">
+            <div className="flex justify-end gap-3 pt-4 border-t border-border-default">
               <Button
                 type="button"
                 variant="outline"
                 onClick={() => toWs(`community/${numericBoardId}`)}
-                className="border-slate-700 text-slate-300 hover:bg-slate-800 hover:text-white"
+                className="border-border-subtle text-text-secondary hover:bg-surface-subtle hover:text-text-primary"
               >
                 취소
               </Button>

--- a/src/features/community/SolutionForm.tsx
+++ b/src/features/community/SolutionForm.tsx
@@ -3,30 +3,32 @@ import { Card, Button, Badge } from '@/components/ui/Base';
 import { ArrowLeft, Save, FileCode, MessageSquare, Tag } from 'lucide-react';
 import Editor from '@monaco-editor/react';
 import { useRecoilValue } from 'recoil';
-import { useNavigate } from 'react-router-dom';
+import { useWorkspaceNavigate } from '@/hooks/useWorkspaceNavigate';
 import { ideCodeState, ideLanguageState } from '@/store/atoms';
+import { useIsDark } from '@/App';
 
 export const SolutionForm = () => {
-  const navigate = useNavigate();
+  const { toWs } = useWorkspaceNavigate();
+  const isDark = useIsDark();
   const code = useRecoilValue(ideCodeState);
   const language = useRecoilValue(ideLanguageState);
 
   const handleRegister = () => {
     // Logic to save the post would go here
     // Redirect to the community/solution view page
-    navigate('/community');
+    toWs('community');
   };
 
   return (
-    <div className="flex h-full flex-col bg-[#0F1117] text-slate-300">
+    <div className="flex h-full flex-col bg-page text-text-secondary">
       {/* Header */}
-      <div className="h-14 border-b border-slate-800 flex items-center justify-between px-4 bg-[#0F1117]">
+      <div className="h-14 border-b border-border-default flex items-center justify-between px-4 bg-page">
         <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={() => navigate('/ide')} className="text-slate-400 hover:text-slate-100">
+          <Button variant="ghost" size="sm" onClick={() => toWs('ide')} className="text-text-muted hover:text-text-primary">
             <ArrowLeft className="w-4 h-4 mr-2" /> 돌아가기
           </Button>
-          <div className="h-4 w-px bg-slate-800" />
-          <h1 className="font-semibold text-slate-100">풀이 공유하기</h1>
+          <div className="h-4 w-px bg-surface-subtle" />
+          <h1 className="font-semibold text-text-primary">풀이 공유하기</h1>
         </div>
 
         <Button
@@ -40,15 +42,15 @@ export const SolutionForm = () => {
 
       <div className="flex-1 flex overflow-hidden">
         {/* Left Panel: Read-only Code View */}
-        <div className="w-1/2 border-r border-slate-800 flex flex-col bg-[#1e1e1e]">
-          <div className="h-10 border-b border-slate-800 flex items-center px-4 bg-[#0F1117]">
+        <div className="w-1/2 border-r border-border-subtle flex flex-col bg-surface-overlay">
+          <div className="h-10 border-b border-border-default flex items-center px-4 bg-page">
             <FileCode className="w-4 h-4 text-emerald-500 mr-2" />
-            <span className="text-xs font-medium text-slate-300">My Solution ({language})</span>
+            <span className="text-xs font-medium text-text-secondary">My Solution ({language})</span>
           </div>
           <div className="flex-1 relative">
             <Editor
               height="100%"
-              theme="vs-dark"
+              theme={isDark ? 'vs-dark' : 'light'}
               language={language}
               value={code}
               options={{
@@ -66,34 +68,34 @@ export const SolutionForm = () => {
         </div>
 
         {/* Right Panel: Write Post */}
-        <div className="flex-1 flex flex-col bg-[#0F1117] overflow-y-auto">
+        <div className="flex-1 flex flex-col bg-page overflow-y-auto">
           <div className="p-8 max-w-2xl mx-auto w-full space-y-6">
             <div className="space-y-2">
-              <label className="text-sm font-semibold text-slate-300">제목</label>
+              <label className="text-sm font-semibold text-text-secondary">제목</label>
               <input
                 type="text"
                 placeholder="풀이의 핵심 내용을 요약해주세요"
-                className="w-full h-12 bg-slate-900 border border-slate-800 rounded-lg px-4 text-slate-200 placeholder:text-slate-600 focus:outline-none focus:border-emerald-500 transition-colors"
+                className="w-full h-12 bg-input-bg border border-border-default rounded-lg px-4 text-text-secondary placeholder:text-text-faint focus:outline-none focus:border-emerald-500 transition-colors"
               />
             </div>
 
             {/* Description Removed as per request */}
 
             <div className="space-y-2">
-              <label className="text-sm font-semibold text-slate-300 flex items-center gap-2">
+              <label className="text-sm font-semibold text-text-secondary flex items-center gap-2">
                 <Tag className="w-4 h-4" /> 태그
               </label>
-              <div className="p-3 bg-slate-900 border border-slate-800 rounded-lg flex flex-wrap gap-2 min-h-[50px]">
-                <Badge variant="default" className="bg-slate-800 pr-1 gap-1">
-                  DP <button className="hover:text-red-400">×</button>
+              <div className="p-3 bg-input-bg border border-border-default rounded-lg flex flex-wrap gap-2 min-h-[50px]">
+                <Badge variant="default" className="bg-surface-subtle pr-1 gap-1">
+                  DP <button className="hover:text-red-600 dark:hover:text-red-400">×</button>
                 </Badge>
-                <Badge variant="default" className="bg-slate-800 pr-1 gap-1">
-                  Greedy <button className="hover:text-red-400">×</button>
+                <Badge variant="default" className="bg-surface-subtle pr-1 gap-1">
+                  Greedy <button className="hover:text-red-600 dark:hover:text-red-400">×</button>
                 </Badge>
                 <input
                   type="text"
                   placeholder="태그 입력..."
-                  className="bg-transparent border-none text-sm text-slate-300 focus:outline-none min-w-[100px]"
+                  className="bg-transparent border-none text-sm text-text-secondary focus:outline-none min-w-[100px]"
                 />
               </div>
             </div>
@@ -102,7 +104,7 @@ export const SolutionForm = () => {
               <MessageSquare className="w-5 h-5 text-emerald-500 flex-shrink-0 mt-0.5" />
               <div>
                 <h4 className="text-sm font-semibold text-emerald-400 mb-1">풀이 공유 팁</h4>
-                <p className="text-xs text-slate-400 leading-relaxed">
+                <p className="text-xs text-text-muted leading-relaxed">
                   다른 사용자들이 이해하기 쉽도록 변수명과 로직을 명확하게 설명해주세요.
                   코드 복잡도(Big-O)를 포함하면 더 좋은 평가를 받을 수 있습니다.
                 </p>

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -57,14 +57,14 @@ export const Dashboard = () => {
 
   if (!currentWorkspace) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center bg-[#0a0c10] text-slate-400 p-8">
+      <div className="flex-1 flex flex-col items-center justify-center bg-page text-text-muted p-8">
         <div className="text-center space-y-4">
           <p className="text-lg">선택된 워크스페이스가 없습니다.</p>
           <Button onClick={() => setCreateWorkspaceOpen(true)} className="bg-indigo-600 hover:bg-indigo-700 text-white">
             새 워크스페이스 생성하기
           </Button>
           <div className="mt-4">
-            <Button variant="ghost" onClick={() => navigate('/explore')} className="text-slate-500 hover:text-slate-300">
+            <Button variant="ghost" onClick={() => navigate('/explore')} className="text-text-faint hover:text-text-secondary">
               워크스페이스 탐색하기
             </Button>
           </div>
@@ -74,21 +74,21 @@ export const Dashboard = () => {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto bg-[#0a0c10] p-8 pb-12 relative font-sans text-slate-100">
+    <div className="flex-1 overflow-y-auto bg-page p-8 pb-12 relative font-sans text-text-primary">
       <div className="max-w-6xl mx-auto space-y-10">
 
         {/* 워크스페이스 헤더 (Notion Style) */}
-        <div className="border-b border-slate-800 pb-8 mt-2 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+        <div className="border-b border-border-default pb-8 mt-2 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div className="flex-1">
-            <h1 className="text-4xl font-extrabold text-white tracking-tight mb-3">{currentWorkspace.name}</h1>
-            <p className="text-base text-slate-400 font-medium leading-relaxed max-w-3xl">
+            <h1 className="text-4xl font-extrabold text-text-primary tracking-tight mb-3">{currentWorkspace.name}</h1>
+            <p className="text-base text-text-muted font-medium leading-relaxed max-w-3xl">
               {currentWorkspace.description || '알고리즘 문제 풀이와 코딩 테스트 대비를 위한 공용 스터디 워크스페이스입니다. 다같이 목표를 달성해봅시다!'}
             </p>
           </div>
           <Button
             variant="outline"
             onClick={() => navigate('/profile')}
-            className="border-indigo-500/30 text-indigo-400 hover:bg-indigo-500/10 hover:text-indigo-300 font-bold shrink-0 items-center justify-center py-2 px-4 shadow-sm transition-all"
+            className="border-indigo-500/30 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-500/10 hover:text-indigo-500 dark:hover:text-indigo-300 font-bold shrink-0 items-center justify-center py-2 px-4 shadow-sm transition-all"
           >
             <UserCircle className="w-5 h-5 mr-1" />
             마이페이지 이동
@@ -101,26 +101,26 @@ export const Dashboard = () => {
           {/* 최근 공지사항 */}
           <section className="flex flex-col">
             <div className="flex justify-between items-center mb-3">
-              <h2 className="text-lg font-bold text-slate-200 flex items-center gap-2">
+              <h2 className="text-lg font-bold text-text-secondary flex items-center gap-2">
                 <span className="w-1.5 h-6 bg-indigo-500 rounded-full"></span>
                 최근 공지사항
               </h2>
-              <span onClick={() => toWs('community')} className="text-xs text-indigo-400 font-medium cursor-pointer hover:underline">더보기</span>
+              <span onClick={() => toWs('community')} className="text-xs text-indigo-600 dark:text-indigo-400 font-medium cursor-pointer hover:underline">더보기</span>
             </div>
             <div className="flex flex-col gap-2.5 flex-1 w-full relative">
               {mockNotices.map(notice => (
                 <Card
                   key={notice.id}
-                  className="bg-[#151922] border-slate-800 p-4 cursor-pointer hover:border-slate-600 transition-colors flex flex-col justify-between flex-1"
+                  className="bg-surface-raised border-border-default p-4 cursor-pointer hover:border-border-subtle transition-colors flex flex-col justify-between flex-1"
                   onClick={() => setSelectedNotice(notice)}
                 >
-                  <h3 className="text-sm font-bold text-slate-200 mb-3 truncate">{notice.title}</h3>
-                  <div className="flex items-center justify-between text-[10px] text-slate-500">
+                  <h3 className="text-sm font-bold text-text-secondary mb-3 truncate">{notice.title}</h3>
+                  <div className="flex items-center justify-between text-[10px] text-text-faint">
                     <div className="flex items-center gap-2">
-                      <span className="text-slate-400 font-medium">{notice.author}</span>
+                      <span className="text-text-muted font-medium">{notice.author}</span>
                       <span>{notice.date}</span>
                     </div>
-                    <span className="px-2 py-0.5 bg-[#1e2330] border border-slate-700 rounded text-slate-300">{notice.type}</span>
+                    <span className="px-2 py-0.5 bg-surface-subtle border border-border-subtle rounded text-text-secondary">{notice.type}</span>
                   </div>
                 </Card>
               ))}
@@ -130,29 +130,29 @@ export const Dashboard = () => {
           {/* 기한 만료 임박 문제 */}
           <section className="flex flex-col">
             <div className="flex justify-between items-center mb-3">
-              <h2 className="text-lg font-bold text-slate-200 flex items-center gap-2">
+              <h2 className="text-lg font-bold text-text-secondary flex items-center gap-2">
                 <span className="w-1.5 h-6 bg-emerald-500 rounded-full"></span>
                 기한 만료 임박 문제
               </h2>
-              <span onClick={() => toWs('problems')} className="text-xs text-emerald-400 font-medium cursor-pointer hover:underline">문제 보러가기</span>
+              <span onClick={() => toWs('problems')} className="text-xs text-emerald-600 dark:text-emerald-400 font-medium cursor-pointer hover:underline">문제 보러가기</span>
             </div>
             <div className="flex flex-col gap-2.5 flex-1 w-full relative">
               {mockProblems.slice(0, 3).map((problem) => (
-                <Card key={problem.id} className="bg-[#151922] border-slate-800 p-4 flex flex-col justify-between cursor-pointer flex-1 hover:border-slate-600 transition-colors">
+                <Card key={problem.id} className="bg-surface-raised border-border-default p-4 flex flex-col justify-between cursor-pointer flex-1 hover:border-border-subtle transition-colors">
                   <div className="flex items-center justify-between mb-3">
-                    <h3 className="text-sm font-bold text-slate-200 truncate">{problem.title}</h3>
+                    <h3 className="text-sm font-bold text-text-secondary truncate">{problem.title}</h3>
                     <div className="flex gap-1 shrink-0">
-                      <span className="px-2 py-0.5 text-[10px] font-medium bg-slate-800 text-slate-300 rounded border border-slate-700">{problem.source}</span>
-                      <span className="px-2 py-0.5 text-[10px] font-medium bg-emerald-900/30 text-emerald-400 rounded border border-emerald-800/50">{problem.difficulty}</span>
+                      <span className="px-2 py-0.5 text-[10px] font-medium bg-surface-subtle text-text-secondary rounded border border-border-subtle">{problem.source}</span>
+                      <span className="px-2 py-0.5 text-[10px] font-medium bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 rounded border border-emerald-200 dark:border-emerald-800/50">{problem.difficulty}</span>
                     </div>
                   </div>
-                  <div className="flex items-center justify-between text-[10px] text-slate-500">
+                  <div className="flex items-center justify-between text-[10px] text-text-faint">
                     <div className="flex gap-1 overflow-hidden">
                       {problem.tags.map(tag => (
                         <span key={tag}>#{tag}</span>
                       ))}
                     </div>
-                    <span className="shrink-0 font-medium text-emerald-400">{problem.date}</span>
+                    <span className="shrink-0 font-medium text-emerald-600 dark:text-emerald-400">{problem.date}</span>
                   </div>
                 </Card>
               ))}
@@ -162,21 +162,21 @@ export const Dashboard = () => {
           {/* 워크스페이스 통계 */}
           <section className="flex flex-col">
             <div className="flex justify-between items-center mb-3">
-              <h2 className="text-lg font-bold text-slate-200 flex items-center gap-2">
+              <h2 className="text-lg font-bold text-text-secondary flex items-center gap-2">
                 <span className="w-1.5 h-6 bg-blue-500 rounded-full"></span>
                 요약 통계
               </h2>
             </div>
             <div className="flex flex-col gap-2.5 flex-1 w-full relative">
-              <Card className="bg-[#151922] border-slate-800 p-4 flex-1 flex flex-col justify-center shadow-md hover:border-slate-600 transition-colors cursor-pointer">
-                <h3 className="text-sm font-medium text-slate-400 mb-1">이번 달 해결</h3>
-                <div className="text-2xl font-extrabold text-white tracking-tight">342<span className="text-xs ml-1 text-slate-500 font-medium">문제</span></div>
-                <div className="text-[11px] text-emerald-400 mt-1 font-bold">+15% (상승곡선 유지 중)</div>
+              <Card className="bg-surface-raised border-border-default p-4 flex-1 flex flex-col justify-center shadow-md hover:border-border-subtle transition-colors cursor-pointer">
+                <h3 className="text-sm font-medium text-text-muted mb-1">이번 달 해결</h3>
+                <div className="text-2xl font-extrabold text-text-primary tracking-tight">342<span className="text-xs ml-1 text-text-faint font-medium">문제</span></div>
+                <div className="text-[11px] text-emerald-600 dark:text-emerald-400 mt-1 font-bold">+15% (상승곡선 유지 중)</div>
               </Card>
-              <Card className="bg-[#151922] border-slate-800 p-4 flex-1 flex flex-col justify-center shadow-md hover:border-slate-600 transition-colors cursor-pointer">
-                <h3 className="text-sm font-medium text-slate-400 mb-1">전체 평균 정답률</h3>
-                <div className="text-2xl font-extrabold text-white tracking-tight">87<span className="text-xs ml-1 text-slate-500 font-medium">%</span></div>
-                <div className="text-[11px] text-blue-400 mt-1 font-bold">오답 노트 적극 활용 요망</div>
+              <Card className="bg-surface-raised border-border-default p-4 flex-1 flex flex-col justify-center shadow-md hover:border-border-subtle transition-colors cursor-pointer">
+                <h3 className="text-sm font-medium text-text-muted mb-1">전체 평균 정답률</h3>
+                <div className="text-2xl font-extrabold text-text-primary tracking-tight">87<span className="text-xs ml-1 text-text-faint font-medium">%</span></div>
+                <div className="text-[11px] text-blue-600 dark:text-blue-400 mt-1 font-bold">오답 노트 적극 활용 요망</div>
               </Card>
             </div>
           </section>
@@ -187,23 +187,23 @@ export const Dashboard = () => {
         {/* 워크스페이스 명예의 전당 (Top 5 랭킹 3종) */}
         <section>
           <div className="flex justify-between items-center mb-4">
-            <h2 className="text-lg font-bold text-slate-200 flex items-center gap-2">
+            <h2 className="text-lg font-bold text-text-secondary flex items-center gap-2">
               <span className="w-1.5 h-6 bg-yellow-500 rounded-full"></span>
               명예의 전당
             </h2>
-            <span className="text-xs text-slate-500 font-medium">Top 5 순위표</span>
+            <span className="text-xs text-text-faint font-medium">Top 5 순위표</span>
           </div>
 
-          <Card className="bg-[#151922] border-slate-800 p-0 overflow-hidden shadow-md">
+          <Card className="bg-surface-raised border-border-default p-0 overflow-hidden shadow-md">
             {/* 탭 헤더 영역 */}
-            <div className="flex border-b border-slate-800/60 bg-[#0f1117]/50">
+            <div className="flex border-b border-border-default/60 bg-page/50">
               {(['정답률', '풀이 수', '연속 출석'] as const).map(tab => (
                 <button
                   key={tab}
                   onClick={() => setActiveRankingTab(tab)}
                   className={`flex-1 py-4 text-sm font-bold transition-all ${activeRankingTab === tab
-                    ? 'text-yellow-500 border-b-2 border-yellow-500 bg-[#151922]'
-                    : 'text-slate-500 hover:text-slate-300 hover:bg-[#151922]/50'
+                    ? 'text-yellow-500 border-b-2 border-yellow-500 bg-surface-raised'
+                    : 'text-text-faint hover:text-text-secondary hover:bg-surface-raised/50'
                     }`}
                 >
                   <div className="flex items-center justify-center gap-2">
@@ -222,33 +222,33 @@ export const Dashboard = () => {
                 {(activeRankingTab === '정답률' ? mockRankingsLevel
                   : activeRankingTab === '풀이 수' ? mockRankingsSolved
                     : mockRankingsComments).map((rank, idx) => (
-                      <div key={rank.id} className="flex items-center justify-between py-3.5 border-b border-slate-800/40 last:border-0 group hover:px-2 rounded-lg hover:bg-slate-800/40 transition-all duration-200 cursor-default">
+                      <div key={rank.id} className="flex items-center justify-between py-3.5 border-b border-border-default/40 last:border-0 group hover:px-2 rounded-lg hover:bg-hover-bg transition-all duration-200 cursor-default">
                         <div className="flex items-center gap-4">
                           {/* 순위 하이라이트 */}
                           <div className={`w-8 h-8 rounded-full flex items-center justify-center font-extrabold text-sm ${idx === 0 ? 'bg-gradient-to-br from-yellow-400 to-amber-600 text-yellow-950 shadow-[0_0_12px_rgba(234,179,8,0.4)]' :
                             idx === 1 ? 'bg-gradient-to-br from-slate-300 to-slate-400 text-slate-900 shadow-[0_0_8px_rgba(148,163,184,0.3)]' :
                               idx === 2 ? 'bg-gradient-to-br from-amber-600 to-amber-800 text-amber-50 shadow-[0_0_8px_rgba(180,83,9,0.3)]' :
-                                'bg-transparent text-slate-500 border border-slate-700/50'
+                                'bg-transparent text-text-faint border border-border-subtle/50'
                             }`}>
                             {idx + 1}
                           </div>
 
                           {/* 유저 아바타 및 이름 */}
                           <div className="flex items-center gap-3">
-                            <div className={`w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold text-slate-300 ${idx === 0 ? 'bg-slate-800 border-2 border-yellow-500/50' : 'bg-slate-800'}`}>
+                            <div className={`w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold text-text-secondary ${idx === 0 ? 'bg-surface-subtle border-2 border-yellow-500/50' : 'bg-surface-subtle'}`}>
                               {rank.name.charAt(0)}
                             </div>
-                            <span className={`font-semibold tracking-tight ${idx === 0 ? 'text-white text-base' : 'text-slate-200 text-[15px]'}`}>
+                            <span className={`font-semibold tracking-tight ${idx === 0 ? 'text-text-primary text-base' : 'text-text-secondary text-[15px]'}`}>
                               {rank.name}
                             </span>
                           </div>
                         </div>
 
                         {/* 기록 데이터 */}
-                        <span className={`font-black tracking-tight ${idx === 0 && activeRankingTab === '정답률' ? 'text-yellow-400 text-lg' :
-                          idx === 0 && activeRankingTab === '풀이 수' ? 'text-emerald-400 text-lg' :
-                            idx === 0 && activeRankingTab === '연속 출석' ? 'text-blue-400 text-lg' :
-                              'text-slate-400 text-sm'
+                        <span className={`font-black tracking-tight ${idx === 0 && activeRankingTab === '정답률' ? 'text-yellow-600 dark:text-yellow-400 text-lg' :
+                          idx === 0 && activeRankingTab === '풀이 수' ? 'text-emerald-600 dark:text-emerald-400 text-lg' :
+                            idx === 0 && activeRankingTab === '연속 출석' ? 'text-blue-600 dark:text-blue-400 text-lg' :
+                              'text-text-muted text-sm'
                           }`}>
                           {rank.count}
                         </span>
@@ -264,22 +264,22 @@ export const Dashboard = () => {
       {/* 모달: 공지글 상세 */}
       {selectedNotice && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-          <div className="bg-[#151922] border border-slate-700 rounded-xl w-full max-w-lg shadow-2xl relative animate-in fade-in zoom-in duration-200">
+          <div className="bg-surface-raised border border-border-subtle rounded-xl w-full max-w-lg shadow-2xl relative animate-in fade-in zoom-in duration-200">
             <button
               onClick={() => setSelectedNotice(null)}
-              className="absolute top-4 right-4 text-slate-500 hover:text-white transition-colors"
+              className="absolute top-4 right-4 text-text-faint hover:text-text-primary transition-colors"
             >
               <X className="w-5 h-5" />
             </button>
-            <div className="p-6 border-b border-slate-800">
-              <h3 className="text-xl font-bold text-slate-100 pr-8">{selectedNotice.title}</h3>
-              <div className="flex items-center gap-2 mt-3 text-sm text-slate-400">
+            <div className="p-6 border-b border-border-default">
+              <h3 className="text-xl font-bold text-text-primary pr-8">{selectedNotice.title}</h3>
+              <div className="flex items-center gap-2 mt-3 text-sm text-text-muted">
                 <span>{selectedNotice.date}</span>
                 <span className="w-1 h-1 rounded-full bg-slate-600"></span>
                 <span>작성자: {selectedNotice.author}</span>
               </div>
             </div>
-            <div className="p-6 text-slate-300 leading-relaxed whitespace-pre-line text-sm min-h-[150px]">
+            <div className="p-6 text-text-secondary leading-relaxed whitespace-pre-line text-sm min-h-[150px]">
               {selectedNotice.content}
             </div>
           </div>

--- a/src/features/explore/WorkspaceExplore.tsx
+++ b/src/features/explore/WorkspaceExplore.tsx
@@ -128,26 +128,26 @@ export const WorkspaceExplore = () => {
     };
 
     return (
-        <div className="flex-1 overflow-y-auto bg-[#0F1117] p-8 pb-24">
+        <div className="flex-1 overflow-y-auto bg-page p-8 pb-24">
             <div className="max-w-5xl mx-auto space-y-8">
 
                 {/* 헤더 */}
                 <div>
-                    <h1 className="text-2xl font-bold text-slate-100">워크스페이스 탐색</h1>
-                    <p className="text-slate-400 mt-1">공개 워크스페이스를 탐색하고 원하는 스터디에 참여하세요.</p>
+                    <h1 className="text-2xl font-bold text-text-primary">워크스페이스 탐색</h1>
+                    <p className="text-text-muted mt-1">공개 워크스페이스를 탐색하고 원하는 스터디에 참여하세요.</p>
                 </div>
 
                 {/* 검색바 */}
                 <form onSubmit={handleSearch} className="relative">
                     <div className="flex gap-3">
                         <div className="flex-1 relative">
-                            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-500" />
+                            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-faint" />
                             <input
                                 type="text"
                                 value={searchQuery}
                                 onChange={(e) => setSearchQuery(e.target.value)}
                                 placeholder="워크스페이스 이름, 태그, 키워드로 검색..."
-                                className="w-full h-12 bg-[#141820] border border-slate-800 rounded-xl pl-12 pr-4 text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-indigo-500 transition-colors"
+                                className="w-full h-12 bg-surface border border-border-default rounded-xl pl-12 pr-4 text-text-secondary placeholder:text-text-faint focus:outline-none focus:border-indigo-500 transition-colors"
                             />
                         </div>
                         <Button
@@ -163,8 +163,8 @@ export const WorkspaceExplore = () => {
                 {/* 검색 결과 정보 */}
                 {submittedQuery && (
                     <div className="flex items-center justify-between">
-                        <p className="text-sm text-slate-400">
-                            "<span className="text-slate-200 font-medium">{submittedQuery}</span>" 검색 결과 · {filteredWorkspaces.length}개
+                        <p className="text-sm text-text-muted">
+                            "<span className="text-text-secondary font-medium">{submittedQuery}</span>" 검색 결과 · {filteredWorkspaces.length}개
                         </p>
                         {submittedQuery && (
                             <button
@@ -173,7 +173,7 @@ export const WorkspaceExplore = () => {
                                     setSubmittedQuery('');
                                     navigate('/explore', { replace: true });
                                 }}
-                                className="text-sm text-slate-500 hover:text-slate-300 transition-colors"
+                                className="text-sm text-text-faint hover:text-text-secondary transition-colors"
                             >
                                 검색 초기화
                             </button>
@@ -185,39 +185,39 @@ export const WorkspaceExplore = () => {
                 <div className="grid gap-4">
                     {filteredWorkspaces.length === 0 ? (
                         <div className="text-center py-20">
-                            <div className="w-16 h-16 rounded-full bg-slate-800 flex items-center justify-center mx-auto mb-4">
-                                <Search className="w-8 h-8 text-slate-600" />
+                            <div className="w-16 h-16 rounded-full bg-surface-subtle flex items-center justify-center mx-auto mb-4">
+                                <Search className="w-8 h-8 text-text-faint" />
                             </div>
-                            <h3 className="text-lg font-semibold text-slate-300 mb-2">검색 결과가 없습니다</h3>
-                            <p className="text-slate-500">다른 키워드로 검색해보세요.</p>
+                            <h3 className="text-lg font-semibold text-text-secondary mb-2">검색 결과가 없습니다</h3>
+                            <p className="text-text-faint">다른 키워드로 검색해보세요.</p>
                         </div>
                     ) : (
                         filteredWorkspaces.map((ws) => (
                             <div
                                 key={ws.id}
-                                className="group bg-[#141820] border border-slate-800 rounded-xl p-6 hover:border-slate-700 hover:bg-slate-800/30 transition-all"
+                                className="group bg-surface border border-border-default rounded-xl p-6 hover:border-border-subtle hover:bg-hover-bg transition-all"
                             >
                                 <div className="flex items-start gap-4">
                                     {/* 아이콘 */}
-                                    <div className="w-12 h-12 rounded-lg bg-slate-800 flex items-center justify-center text-xl flex-shrink-0 group-hover:bg-slate-700 transition-colors">
+                                    <div className="w-12 h-12 rounded-lg bg-surface-subtle flex items-center justify-center text-xl flex-shrink-0 group-hover:bg-border-subtle transition-colors">
                                         {ws.icon}
                                     </div>
 
                                     {/* 정보 */}
                                     <div className="flex-1 min-w-0">
                                         <div className="flex items-center gap-2 mb-1">
-                                            <h3 className="text-lg font-semibold text-slate-100 group-hover:text-white transition-colors truncate">
+                                            <h3 className="text-lg font-semibold text-text-primary group-hover:text-text-primary transition-colors truncate">
                                                 {ws.name}
                                             </h3>
                                             {ws.isPublic ? (
                                                 <Globe className="w-3.5 h-3.5 text-emerald-500 flex-shrink-0" />
                                             ) : (
-                                                <Lock className="w-3.5 h-3.5 text-slate-500 flex-shrink-0" />
+                                                <Lock className="w-3.5 h-3.5 text-text-faint flex-shrink-0" />
                                             )}
                                         </div>
-                                        <p className="text-sm text-slate-400 mb-3 line-clamp-2">{ws.description}</p>
+                                        <p className="text-sm text-text-muted mb-3 line-clamp-2">{ws.description}</p>
 
-                                        <div className="flex items-center gap-4 text-xs text-slate-500">
+                                        <div className="flex items-center gap-4 text-xs text-text-faint">
                                             <span className="flex items-center gap-1">
                                                 <Users className="w-3.5 h-3.5" />
                                                 {ws.members}명
@@ -231,7 +231,7 @@ export const WorkspaceExplore = () => {
                                             {ws.tags.map(tag => (
                                                 <span
                                                     key={tag}
-                                                    className="px-2 py-0.5 text-xs rounded bg-slate-800 text-slate-400 border border-slate-700 cursor-pointer hover:border-indigo-500/50 hover:text-indigo-400 transition-colors"
+                                                    className="px-2 py-0.5 text-xs rounded bg-surface-subtle text-text-muted border border-border-subtle cursor-pointer hover:border-indigo-500/50 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
                                                     onClick={() => {
                                                         setSearchQuery(tag);
                                                         setSubmittedQuery(tag);

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -71,8 +71,8 @@ export const Home = () => {
 
     if (loading) {
         return (
-            <div className="min-h-screen bg-[#0F1117] flex items-center justify-center">
-                <div className="text-slate-400">워크스페이스 로딩 중...</div>
+            <div className="min-h-screen bg-page flex items-center justify-center">
+                <div className="text-text-muted">워크스페이스 로딩 중...</div>
             </div>
         );
     }
@@ -94,9 +94,9 @@ export const Home = () => {
     };
 
     return (
-        <div className="h-full overflow-y-auto overflow-x-hidden scroll-smooth bg-[#0F1117] text-white flex flex-col relative" id="home-scroll-container">
+        <div className="h-full overflow-y-auto overflow-x-hidden scroll-smooth bg-page text-text-primary flex flex-col relative" id="home-scroll-container">
             {/* Navbar */}
-            <nav className="border-b border-slate-800 bg-[#141820]/80 backdrop-blur-md sticky top-0 z-50">
+            <nav className="border-b border-border-default bg-surface/80 backdrop-blur-md sticky top-0 z-50">
                 <div className="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
                     <div className="flex items-center gap-2">
                         <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-white font-bold">
@@ -110,32 +110,32 @@ export const Home = () => {
                             <div className="relative" ref={profileMenuRef}>
                                 <button
                                     onClick={() => setProfileMenuOpen(!profileMenuOpen)}
-                                    className="flex items-center gap-2.5 px-2 py-1.5 rounded-lg hover:bg-slate-800/60 transition-colors"
+                                    className="flex items-center gap-2.5 px-2 py-1.5 rounded-lg hover:bg-hover-bg transition-colors"
                                 >
                                     <div className="w-8 h-8 rounded-full bg-indigo-600 flex items-center justify-center text-white text-sm font-bold border border-indigo-500">
                                         {user.name.charAt(0)}
                                     </div>
-                                    <span className="text-sm font-medium text-slate-200 hidden sm:block">{user.name}</span>
-                                    <ChevronDown className={`w-3.5 h-3.5 text-slate-400 transition-transform ${profileMenuOpen ? 'rotate-180' : ''}`} />
+                                    <span className="text-sm font-medium text-text-secondary hidden sm:block">{user.name}</span>
+                                    <ChevronDown className={`w-3.5 h-3.5 text-text-muted transition-transform ${profileMenuOpen ? 'rotate-180' : ''}`} />
                                 </button>
 
                                 {profileMenuOpen && (
-                                    <div className="absolute right-0 top-12 w-56 bg-[#1e1e1e] border border-slate-700 rounded-xl shadow-2xl overflow-hidden z-[100] animate-in fade-in zoom-in-95 duration-100">
-                                        <div className="px-4 py-3 border-b border-slate-700/50">
-                                            <div className="text-sm font-medium text-slate-200 truncate">{user.name}</div>
-                                            <div className="text-xs text-slate-500 truncate">{user.email}</div>
+                                    <div className="absolute right-0 top-12 w-56 bg-surface-overlay border border-border-subtle rounded-xl shadow-2xl overflow-hidden z-[100] animate-in fade-in zoom-in-95 duration-100">
+                                        <div className="px-4 py-3 border-b border-border-subtle/50">
+                                            <div className="text-sm font-medium text-text-secondary truncate">{user.name}</div>
+                                            <div className="text-xs text-text-faint truncate">{user.email}</div>
                                         </div>
                                         <div className="py-1">
                                             <button
                                                 onClick={() => { setProfileMenuOpen(false); navigate('/settings'); }}
-                                                className="w-full flex items-center gap-2.5 px-4 py-2 text-sm text-slate-300 hover:bg-slate-700/40 transition-colors"
+                                                className="w-full flex items-center gap-2.5 px-4 py-2 text-sm text-text-secondary hover:bg-hover-bg transition-colors"
                                             >
-                                                <Settings className="w-4 h-4 text-slate-400" />
+                                                <Settings className="w-4 h-4 text-text-muted" />
                                                 설정
                                             </button>
                                             <button
                                                 onClick={handleLogout}
-                                                className="w-full flex items-center gap-2.5 px-4 py-2 text-sm text-red-400 hover:bg-slate-700/40 transition-colors"
+                                                className="w-full flex items-center gap-2.5 px-4 py-2 text-sm text-red-400 hover:bg-hover-bg transition-colors"
                                             >
                                                 <LogOut className="w-4 h-4" />
                                                 로그아웃
@@ -146,7 +146,7 @@ export const Home = () => {
                             </div>
                         ) : (
                             <>
-                                <Button variant="ghost" className="text-slate-400 hover:text-white" onClick={() => navigate('/login')}>
+                                <Button variant="ghost" className="text-text-muted hover:text-text-primary" onClick={() => navigate('/login')}>
                                     로그인
                                 </Button>
                                 <Button className="bg-emerald-600 hover:bg-emerald-700 text-white" onClick={() => navigate('/signup')}>
@@ -164,10 +164,10 @@ export const Home = () => {
                     {/* Background Gradients */}
                     <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-indigo-500/10 rounded-full blur-3xl -z-10 animate-pulse" />
 
-                    <h1 className="text-5xl md:text-7xl font-extrabold mb-6 tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-white to-slate-400 mt-[-4rem]">
+                    <h1 className="text-5xl md:text-7xl font-extrabold mb-6 tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-text-primary to-text-muted mt-[-4rem]">
                         함께 코딩하고,<br />함께 성장하세요.
                     </h1>
-                    <p className="text-lg md:text-xl text-slate-400 max-w-2xl mb-10 leading-relaxed">
+                    <p className="text-lg md:text-xl text-text-muted max-w-2xl mb-10 leading-relaxed">
                         실시간 알고리즘 스터디 플랫폼 UJAX에서<br className="hidden md:block" />
                         팀원들과 함께 코드를 리뷰하고 성장하세요.
                     </p>
@@ -195,7 +195,7 @@ export const Home = () => {
                     <div className="absolute bottom-10 left-1/2 -translate-x-1/2 mx-auto animate-bounce z-20">
                         <button
                             onClick={() => document.getElementById('features')?.scrollIntoView({ behavior: 'smooth' })}
-                            className="p-3 bg-white/5 hover:bg-white/10 rounded-full transition-colors text-slate-400 hover:text-white"
+                            className="p-3 bg-black/5 dark:bg-white/5 hover:bg-black/10 dark:hover:bg-white/10 rounded-full transition-colors text-text-muted hover:text-text-primary"
                         >
                             <ChevronDown className="w-6 h-6" />
                         </button>
@@ -203,56 +203,56 @@ export const Home = () => {
                 </section>
 
                 {/* ═══ Features Section (두 번째 섹션) ═══ */}
-                <section id="features" className="min-h-screen pt-24 pb-32 bg-[#0F1117] flex flex-col justify-center relative overflow-hidden shrink-0">
-                    <div className="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-transparent via-slate-700 to-transparent opacity-50"></div>
+                <section id="features" className="min-h-screen pt-24 pb-32 bg-page flex flex-col justify-center relative overflow-hidden shrink-0">
+                    <div className="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-transparent via-border-default to-transparent opacity-50"></div>
                     <div className="max-w-7xl mx-auto px-6 relative z-10 w-full mb-12">
                         <div className="text-center mb-16 mt-[-2rem]">
-                            <h2 className="text-4xl lg:text-5xl font-extrabold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-white via-indigo-200 to-slate-400">
+                            <h2 className="text-4xl lg:text-5xl font-extrabold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-text-primary via-indigo-500 dark:via-indigo-200 to-text-muted">
                                 왜 UJAX인가요?
                             </h2>
-                            <p className="text-lg text-slate-400 max-w-2xl mx-auto">
+                            <p className="text-lg text-text-muted max-w-2xl mx-auto">
                                 성장에 필요한 모든 것을 담았습니다. 압도적인 몰입감과 실용성을 바탕으로 알고리즘 스터디의 새로운 표준을 제시합니다.
                             </p>
                         </div>
 
                         <div className="grid md:grid-cols-3 gap-8">
                             {/* Card 1 */}
-                            <div className="group relative p-[1px] rounded-2xl bg-gradient-to-b from-slate-800 to-slate-900 hover:from-indigo-500 hover:to-purple-500 transition-all duration-500 hover:-translate-y-2 shadow-xl hover:shadow-indigo-500/25">
-                                <div className="relative h-full bg-[#141820] p-8 rounded-2xl flex flex-col items-start overflow-hidden">
+                            <div className="group relative p-[1px] rounded-2xl bg-gradient-to-b from-border-subtle to-surface-subtle dark:from-slate-800 dark:to-slate-900 hover:from-indigo-500 hover:to-purple-500 transition-all duration-500 hover:-translate-y-2 shadow-xl hover:shadow-indigo-500/25">
+                                <div className="relative h-full bg-surface p-8 rounded-2xl flex flex-col items-start overflow-hidden">
                                     <div className="absolute top-0 right-0 w-32 h-32 bg-indigo-500/10 rounded-full blur-3xl -mr-10 -mt-10 group-hover:bg-indigo-500/30 transition-colors duration-500"></div>
                                     <div className="w-14 h-14 rounded-xl bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-500 shadow-lg shadow-indigo-500/20">
-                                        <Layout className="w-7 h-7 text-indigo-400 group-hover:text-indigo-300" />
+                                        <Layout className="w-7 h-7 text-indigo-600 dark:text-indigo-400 group-hover:text-indigo-500 dark:group-hover:text-indigo-300" />
                                     </div>
-                                    <h3 className="text-2xl font-bold mb-4 text-slate-100 group-hover:text-white transition-colors">독립된 워크스페이스</h3>
-                                    <p className="text-slate-400 leading-relaxed group-hover:text-slate-300 transition-colors">
+                                    <h3 className="text-2xl font-bold mb-4 text-text-primary group-hover:text-text-primary transition-colors">독립된 워크스페이스</h3>
+                                    <p className="text-text-muted leading-relaxed group-hover:text-text-secondary transition-colors">
                                         스터디별로 완벽히 분리된 팀 공간을 제공합니다. 멤버 초대부터 문제집 공유, 공지사항 관리까지 스터디 운영이 한결 쉬워집니다.
                                     </p>
                                 </div>
                             </div>
 
                             {/* Card 2 */}
-                            <div className="group relative p-[1px] rounded-2xl bg-gradient-to-b from-slate-800 to-slate-900 hover:from-emerald-500 hover:to-teal-500 transition-all duration-500 hover:-translate-y-2 shadow-xl hover:shadow-emerald-500/25">
-                                <div className="relative h-full bg-[#141820] p-8 rounded-2xl flex flex-col items-start overflow-hidden">
+                            <div className="group relative p-[1px] rounded-2xl bg-gradient-to-b from-border-subtle to-surface-subtle dark:from-slate-800 dark:to-slate-900 hover:from-emerald-500 hover:to-teal-500 transition-all duration-500 hover:-translate-y-2 shadow-xl hover:shadow-emerald-500/25">
+                                <div className="relative h-full bg-surface p-8 rounded-2xl flex flex-col items-start overflow-hidden">
                                     <div className="absolute top-0 right-0 w-32 h-32 bg-emerald-500/10 rounded-full blur-3xl -mr-10 -mt-10 group-hover:bg-emerald-500/30 transition-colors duration-500"></div>
                                     <div className="w-14 h-14 rounded-xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-500 shadow-lg shadow-emerald-500/20">
                                         <Code2 className="w-7 h-7 text-emerald-400 group-hover:text-emerald-300" />
                                     </div>
-                                    <h3 className="text-2xl font-bold mb-4 text-slate-100 group-hover:text-white transition-colors">강력한 브라우저 IDE</h3>
-                                    <p className="text-slate-400 leading-relaxed group-hover:text-slate-300 transition-colors">
+                                    <h3 className="text-2xl font-bold mb-4 text-text-primary group-hover:text-text-primary transition-colors">강력한 브라우저 IDE</h3>
+                                    <p className="text-text-muted leading-relaxed group-hover:text-text-secondary transition-colors">
                                         번거로운 환경 설정 없이 브라우저에서 즉시 코딩을 시작하세요. 다크 테마, 문법 강조 및 코드 자동 완성을 지원하는 편집기를 경험할 수 있습니다.
                                     </p>
                                 </div>
                             </div>
 
                             {/* Card 3 */}
-                            <div className="group relative p-[1px] rounded-2xl bg-gradient-to-b from-slate-800 to-slate-900 hover:from-purple-500 hover:to-pink-500 transition-all duration-500 hover:-translate-y-2 shadow-xl hover:shadow-purple-500/25">
-                                <div className="relative h-full bg-[#141820] p-8 rounded-2xl flex flex-col items-start overflow-hidden">
+                            <div className="group relative p-[1px] rounded-2xl bg-gradient-to-b from-border-subtle to-surface-subtle dark:from-slate-800 dark:to-slate-900 hover:from-purple-500 hover:to-pink-500 transition-all duration-500 hover:-translate-y-2 shadow-xl hover:shadow-purple-500/25">
+                                <div className="relative h-full bg-surface p-8 rounded-2xl flex flex-col items-start overflow-hidden">
                                     <div className="absolute top-0 right-0 w-32 h-32 bg-purple-500/10 rounded-full blur-3xl -mr-10 -mt-10 group-hover:bg-purple-500/30 transition-colors duration-500"></div>
                                     <div className="w-14 h-14 rounded-xl bg-purple-500/10 border border-purple-500/20 flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-500 shadow-lg shadow-purple-500/20">
                                         <Monitor className="w-7 h-7 text-purple-400 group-hover:text-purple-300" />
                                     </div>
-                                    <h3 className="text-2xl font-bold mb-4 text-slate-100 group-hover:text-white transition-colors">실시간 코드 피드백</h3>
-                                    <p className="text-slate-400 leading-relaxed group-hover:text-slate-300 transition-colors">
+                                    <h3 className="text-2xl font-bold mb-4 text-text-primary group-hover:text-text-primary transition-colors">실시간 코드 피드백</h3>
+                                    <p className="text-text-muted leading-relaxed group-hover:text-text-secondary transition-colors">
                                         문제 풀이 결과를 투명하게 공유하고 동료들과 의견을 나눕니다. 집단 지성을 통한 코드 리뷰로 더 우수하고 효율적인 최적의 알고리즘을 발견하세요.
                                     </p>
                                 </div>
@@ -264,7 +264,7 @@ export const Home = () => {
                     <div className="absolute bottom-10 left-1/2 -translate-x-1/2 mx-auto animate-bounce z-20">
                         <button
                             onClick={() => document.getElementById('explore')?.scrollIntoView({ behavior: 'smooth' })}
-                            className="p-3 bg-white/5 hover:bg-white/10 rounded-full transition-colors text-slate-400 hover:text-white"
+                            className="p-3 bg-black/5 dark:bg-white/5 hover:bg-black/10 dark:hover:bg-white/10 rounded-full transition-colors text-text-muted hover:text-text-primary"
                         >
                             <ChevronDown className="w-6 h-6" />
                         </button>
@@ -272,25 +272,25 @@ export const Home = () => {
                 </section>
 
                 {/* ═══ 탐색 섹션 (마지막 섹션) ═══ */}
-                <section id="explore" className="min-h-screen py-16 bg-[#0a0d13] flex flex-col justify-center shrink-0 relative">
+                <section id="explore" className="min-h-screen py-16 bg-page-deep flex flex-col justify-center shrink-0 relative">
                     <div className="max-w-3xl mx-auto px-6 text-center w-full mt-[-2rem]">
-                        <h2 className="text-3xl md:text-4xl font-bold text-slate-100 mb-4">
+                        <h2 className="text-3xl md:text-4xl font-bold text-text-primary mb-4">
                             워크스페이스 탐색
                         </h2>
-                        <p className="text-lg text-slate-400 mb-10">
+                        <p className="text-lg text-text-muted mb-10">
                             공개 스터디를 찾아 참여하세요. 같은 목표를 가진 동료들과 함께 성장할 수 있습니다.
                         </p>
 
                         {/* 탐색 검색바 */}
                         <form onSubmit={handleExploreSearch} className="flex gap-3 max-w-xl mx-auto">
                             <div className="flex-1 relative">
-                                <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-500" />
+                                <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-faint" />
                                 <input
                                     type="text"
                                     value={exploreQuery}
                                     onChange={(e) => setExploreQuery(e.target.value)}
                                     placeholder="스터디 이름, 태그 검색..."
-                                    className="w-full h-14 bg-[#141820] border border-slate-700 rounded-xl pl-12 pr-4 text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-indigo-500 transition-colors shadow-lg"
+                                    className="w-full h-14 bg-surface border border-border-subtle rounded-xl pl-12 pr-4 text-text-secondary placeholder:text-text-faint focus:outline-none focus:border-indigo-500 transition-colors shadow-lg"
                                 />
                             </div>
                             <Button
@@ -311,7 +311,7 @@ export const Home = () => {
                                         setExploreQuery(tag);
                                         navigate(`/explore?q=${encodeURIComponent(tag)}`);
                                     }}
-                                    className="px-4 py-2 text-sm rounded-full bg-slate-800 text-slate-400 border border-slate-700 hover:border-indigo-500/50 hover:text-indigo-400 hover:bg-indigo-500/10 transition-colors"
+                                    className="px-4 py-2 text-sm rounded-full bg-surface-subtle text-text-muted border border-border-subtle hover:border-indigo-500/50 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-indigo-500/10 transition-colors"
                                 >
                                     #{tag}
                                 </button>
@@ -321,7 +321,7 @@ export const Home = () => {
                 </section>
 
                 {/* Footer */}
-                <footer className="border-t border-slate-800 py-12 text-center text-slate-500 text-sm">
+                <footer className="border-t border-border-default py-12 text-center text-text-faint text-sm">
                     <p>&copy; {new Date().getFullYear()} UJAX Platform. All rights reserved.</p>
                 </footer>
             </main>

--- a/src/features/ide/IDE.tsx
+++ b/src/features/ide/IDE.tsx
@@ -1,11 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { Card, Button, Badge } from '@/components/ui/Base';
-import { Play, RotateCcw, Save, Settings, CheckCircle2, AlertCircle, Loader2, Share, ArrowLeft, Timer, ChevronDown, ChevronRight, Plus, Code2 } from 'lucide-react';
+import { Play, RotateCcw, Settings, CheckCircle2, AlertCircle, Loader2, ArrowLeft, Timer, ChevronDown, ChevronRight, Plus, Code2, Clock, HardDrive } from 'lucide-react';
 import Editor from '@monaco-editor/react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { useParams } from 'react-router-dom';
 import { useWorkspaceNavigate } from '@/hooks/useWorkspaceNavigate';
 import { ideCodeState, ideLanguageState, ideOutputState, ideIsExecutingState, IdeOutput } from '@/store/atoms';
+import { getProblemByNumber } from '@/api/problem';
+import type { ProblemResponse } from '@/api/problem';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
+import { useIsDark } from '@/App';
 
 // Language ID mapping for Judge0
 const LANGUAGE_OPTIONS = [
@@ -56,7 +60,6 @@ public class Main {
 }`
 };
 
-// Simple Stopwatch Component
 const Stopwatch = () => {
   const [time, setTime] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
@@ -64,28 +67,23 @@ const Stopwatch = () => {
   useEffect(() => {
     let interval: any;
     if (isRunning) {
-      interval = setInterval(() => {
-        setTime((prevTime) => prevTime + 1);
-      }, 1000);
-    } else if (!isRunning) {
-      clearInterval(interval);
+      interval = setInterval(() => setTime((t) => t + 1), 1000);
     }
     return () => clearInterval(interval);
   }, [isRunning]);
 
-  const formatTime = (seconds: number) => {
-    const getSeconds = `0${seconds % 60}`.slice(-2);
-    const minutes = Math.floor(seconds / 60);
-    const getMinutes = `0${minutes % 60}`.slice(-2);
-    const getHours = `0${Math.floor(seconds / 3600)}`.slice(-2);
-    return `${getHours}:${getMinutes}:${getSeconds}`;
+  const fmt = (s: number) => {
+    const ss = `0${s % 60}`.slice(-2);
+    const mm = `0${Math.floor(s / 60) % 60}`.slice(-2);
+    const hh = `0${Math.floor(s / 3600)}`.slice(-2);
+    return `${hh}:${mm}:${ss}`;
   };
 
   return (
-    <div className="flex items-center gap-2 bg-slate-800 rounded px-2 py-1 text-xs font-mono text-slate-300">
-      <Timer className="w-3 h-3 text-emerald-500" />
-      <span>{formatTime(time)}</span>
-      <button onClick={() => setIsRunning(!isRunning)} className="hover:text-white">
+    <div className="flex items-center gap-2 bg-surface-subtle rounded px-3 py-1.5 text-sm font-mono text-text-secondary">
+      <Timer className="w-3.5 h-3.5 text-emerald-500" />
+      <span>{fmt(time)}</span>
+      <button onClick={() => setIsRunning(!isRunning)} className="hover:text-text-primary">
         {isRunning ? 'II' : '▶'}
       </button>
     </div>
@@ -93,6 +91,7 @@ const Stopwatch = () => {
 };
 
 export const IDE = () => {
+  const isDark = useIsDark();
   const [code, setCode] = useRecoilState(ideCodeState);
   const [language, setLanguage] = useRecoilState(ideLanguageState);
   const [output, setOutput] = useRecoilState(ideOutputState);
@@ -100,330 +99,315 @@ export const IDE = () => {
   const { navigate, toWs } = useWorkspaceNavigate();
   const { problemId } = useParams();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [problem, setProblem] = useState<ProblemResponse | null>(null);
+  const [problemLoading, setProblemLoading] = useState(false);
+  const [problemError, setProblemError] = useState('');
 
-  // Sections state for collapsible
-  const [openSections, setOpenSections] = useState({
-    problem: true,
-    tests: false
-  });
+  const [testOpen, setTestOpen] = useState(false);
 
-  const toggleSection = (section: 'problem' | 'tests') => {
-    setOpenSections(prev => ({ ...prev, [section]: !prev[section] }));
-  };
+  useEffect(() => {
+    if (!problemId) return;
+    const num = parseInt(problemId, 10);
+    if (!num || num <= 0) return;
+    setProblemLoading(true);
+    setProblemError('');
+    getProblemByNumber(num)
+      .then((data) => setProblem(data))
+      .catch((err) => {
+        const msg = err?.message || '';
+        const jsonMatch = msg.match(/\{[\s\S]*\}/);
+        if (jsonMatch) {
+          try { setProblemError(JSON.parse(jsonMatch[0]).detail || '문제를 불러오는 데 실패했습니다.'); }
+          catch { setProblemError('문제를 불러오는 데 실패했습니다.'); }
+        } else { setProblemError('문제를 불러오는 데 실패했습니다.'); }
+      })
+      .finally(() => setProblemLoading(false));
+  }, [problemId]);
 
-  // Initialize code with template if empty or if it matches the default 'Hello World'
   useEffect(() => {
     if (code.includes('Hello, World!') || code.trim() === '') {
       setCode(CODE_TEMPLATES[language] || '');
     }
   }, []);
 
-  const handleEditorChange = (value: string | undefined) => {
-    if (value !== undefined) {
-      setCode(value);
-    }
-  };
-
   const handleLanguageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const selectedLang = LANGUAGE_OPTIONS.find(lang => lang.value === e.target.value);
-    if (selectedLang) {
-      setLanguage(selectedLang.value);
-      // Automatically switch to the template for the new language
-      setCode(CODE_TEMPLATES[selectedLang.value] || '');
-    }
+    const lang = LANGUAGE_OPTIONS.find(l => l.value === e.target.value);
+    if (lang) { setLanguage(lang.value); setCode(CODE_TEMPLATES[lang.value] || ''); }
   };
 
   const executeCode = async () => {
     setIsExecuting(true);
-    setOpenSections(prev => ({ ...prev, tests: true })); // Auto open tests
+    setTestOpen(true);
     setOutput(null);
-
-    // Mock Judge0 API call
     try {
-      await new Promise(resolve => setTimeout(resolve, 1500));
-
-      const mockResponse = {
-        stdout: "3\n",
-        stderr: null,
-        status: { id: 3, description: "Accepted" },
-        time: "0.045",
-        memory: "12480"
-      };
-
+      await new Promise(r => setTimeout(r, 1500));
       if (code.includes("error")) {
-        setOutput({
-          stdout: null,
-          stderr: "ReferenceError: error is not defined\n    at Object.<anonymous> (/script.js:1:1)",
-          status: { id: 11, description: "Runtime Error" },
-          time: "0.050",
-          memory: "13000"
-        });
+        setOutput({ stdout: null, stderr: "ReferenceError: error is not defined\n    at Object.<anonymous> (/script.js:1:1)", status: { id: 11, description: "Runtime Error" }, time: "0.050", memory: "13000" });
       } else {
-        setOutput(mockResponse);
+        setOutput({ stdout: "3\n", stderr: null, status: { id: 3, description: "Accepted" }, time: "0.045", memory: "12480" });
       }
-
-    } catch (error) {
-      setOutput({
-        stdout: null,
-        stderr: "Failed to execute code. Please check your connection.",
-        status: { id: 0, description: "Network Error" },
-        time: null,
-        memory: null
-      } as IdeOutput);
-    } finally {
-      setIsExecuting(false);
-    }
+    } catch {
+      setOutput({ stdout: null, stderr: "Failed to execute code.", status: { id: 0, description: "Network Error" }, time: null, memory: null } as IdeOutput);
+    } finally { setIsExecuting(false); }
   };
 
   const handleSubmit = async () => {
     if (isSubmitting || isExecuting) return;
-
     setIsSubmitting(true);
-    setOpenSections(prev => ({ ...prev, tests: true }));
+    setTestOpen(true);
     setOutput(null);
-
     try {
-      // Mock Submission Delay
-      await new Promise(resolve => setTimeout(resolve, 1500));
-
-      // Simulate 'Accepted' result
-      const mockResponse = {
-        stdout: "",
-        stderr: null,
-        status: { id: 3, description: "Accepted" },
-        time: "0.045",
-        memory: "12480"
-      };
-
-      setOutput(mockResponse);
-
-      // If accepted, navigate to solutions list
-      if (mockResponse.status?.id === 3) {
-        setTimeout(() => {
-          navigate(`/problems/${problemId || '1000'}/solutions`);
-        }, 1500);
-      }
-    } catch (error) {
-      setOutput({
-        stdout: null,
-        stderr: "Submission failed.",
-        status: { id: 0, description: "Error" },
-        time: null,
-        memory: null
-      } as IdeOutput);
-    } finally {
-      setIsSubmitting(false);
-    }
+      await new Promise(r => setTimeout(r, 1500));
+      const res = { stdout: "", stderr: null, status: { id: 3, description: "Accepted" }, time: "0.045", memory: "12480" };
+      setOutput(res);
+      if (res.status?.id === 3) setTimeout(() => navigate(`/problems/${problemId || '1000'}/solutions`), 1500);
+    } catch {
+      setOutput({ stdout: null, stderr: "Submission failed.", status: { id: 0, description: "Error" }, time: null, memory: null } as IdeOutput);
+    } finally { setIsSubmitting(false); }
   };
 
   return (
-    <div className="flex h-full flex-col bg-[#0F1117] text-slate-300">
-      {/* IDE Header */}
-      <div className="h-14 border-b border-slate-800 flex items-center justify-between px-4 bg-[#0F1117]">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={() => toWs('problems')}>
-            <ArrowLeft className="w-4 h-4 mr-2" /> 문제집으로
+    <div className="flex h-full flex-col bg-page text-text-secondary">
+      {/* Header */}
+      <div className="h-14 border-b border-border-default flex items-center justify-between px-5 bg-page shrink-0">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" onClick={() => toWs('problems')} className="text-sm">
+            <ArrowLeft className="w-4 h-4 mr-1.5" /> 돌아가기
           </Button>
-          <div className="h-4 w-px bg-slate-800" />
+          <div className="h-5 w-px bg-surface-subtle" />
           <div className="flex items-center gap-2">
-            <Badge variant="success">Easy</Badge>
-            <h1 className="font-semibold text-slate-100">1000. A+B</h1>
+            {problem?.tier && <Badge variant="success">{problem.tier}</Badge>}
+            <h1 className="font-semibold text-text-primary text-base">
+              {problem ? `${problem.problemNumber}. ${problem.title}` : problemId ? `#${problemId}` : '문제'}
+            </h1>
           </div>
         </div>
-
         <div className="flex items-center gap-3">
           <Stopwatch />
-          <div className="h-4 w-px bg-slate-800 mx-2" />
-
+          <div className="h-5 w-px bg-surface-subtle" />
           <select
             value={language}
             onChange={handleLanguageChange}
-            className="bg-slate-900 border border-slate-700 rounded px-2 py-1 text-xs font-medium text-slate-300 focus:outline-none focus:border-emerald-500 cursor-pointer"
+            className="bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm font-medium text-text-secondary focus:outline-none focus:border-emerald-500 cursor-pointer"
           >
             {LANGUAGE_OPTIONS.map(opt => (
               <option key={opt.id} value={opt.value}>{opt.name}</option>
             ))}
           </select>
-
-          <Button variant="ghost" size="sm" onClick={() => setCode(CODE_TEMPLATES[language])}>
+          <Button variant="ghost" onClick={() => setCode(CODE_TEMPLATES[language])}>
             <RotateCcw className="w-4 h-4" />
           </Button>
-          <Button variant="secondary" size="sm"><Settings className="w-4 h-4" /></Button>
+          <Button variant="secondary"><Settings className="w-4 h-4" /></Button>
         </div>
       </div>
 
-      {/* Main Split Area */}
-      <div className="flex-1 flex overflow-hidden">
-        {/* Left Panel: Problem & Tests (Collapsible) */}
-        <div className="w-[40%] border-r border-slate-800 flex flex-col bg-[#0F1117] overflow-y-auto custom-scrollbar">
+      {/* Main: Resizable Left (Problem) | Right (Editor + Test) */}
+      <ResizablePanelGroup direction="horizontal" className="flex-1 min-h-0">
+        {/* ─── Left: Problem ─── */}
+        <ResizablePanel defaultSize={38} minSize={25} maxSize={60}>
+          <div className="h-full flex flex-col bg-page overflow-y-auto custom-scrollbar">
+            <div className="px-5 py-3 bg-surface border-b border-border-default shrink-0">
+              <span className="font-bold text-text-secondary text-sm uppercase tracking-wider">문제 설명</span>
+            </div>
 
-          {/* Problem Details Section */}
-          <div className="border-b border-slate-800">
-            <button
-              onClick={() => toggleSection('problem')}
-              className="w-full flex items-center justify-between px-4 py-3 bg-[#141820] hover:bg-slate-800 transition-colors"
-            >
-              <span className="font-bold text-slate-200 text-sm">Problem Details</span>
-              {openSections.problem ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-            </button>
-
-            {openSections.problem && (
-              <div className="p-6 space-y-6 animate-in slide-in-from-top-2 duration-200">
-                <section>
-                  <h3 className="text-lg font-bold text-slate-100 mb-3">문제</h3>
-                  <p className="text-slate-400 leading-relaxed">
-                    두 정수 A와 B를 입력받은 다음, A+B를 출력하는 프로그램을 작성하시오.
-                  </p>
-                </section>
-
-                <section>
-                  <h3 className="text-lg font-bold text-slate-100 mb-3">입력</h3>
-                  <p className="text-slate-400 leading-relaxed">
-                    첫째 줄에 A와 B가 주어진다. (0 &lt; A, B &lt; 10)
-                  </p>
-                </section>
-
-                <section>
-                  <h3 className="text-lg font-bold text-slate-100 mb-3">출력</h3>
-                  <p className="text-slate-400 leading-relaxed">
-                    첫째 줄에 A+B를 출력한다.
-                  </p>
-                </section>
-
-                <div className="grid grid-cols-2 gap-4">
-                  <Card className="p-4 bg-slate-900 border-slate-800">
-                    <h4 className="text-xs font-semibold text-slate-500 mb-2 uppercase">예제 입력 1</h4>
-                    <code className="text-sm font-mono text-slate-200">1 2</code>
-                  </Card>
-                  <Card className="p-4 bg-slate-900 border-slate-800">
-                    <h4 className="text-xs font-semibold text-slate-500 mb-2 uppercase">예제 출력 1</h4>
-                    <code className="text-sm font-mono text-slate-200">3</code>
-                  </Card>
+            <div className="p-6 space-y-6">
+              {problemLoading ? (
+                <div className="flex justify-center py-12">
+                  <Loader2 className="w-5 h-5 text-text-faint animate-spin" />
                 </div>
-              </div>
-            )}
-          </div>
-
-          {/* Test Results Section */}
-          <div className="border-b border-slate-800">
-            <button
-              onClick={() => toggleSection('tests')}
-              className="w-full flex items-center justify-between px-4 py-3 bg-[#141820] hover:bg-slate-800 transition-colors"
-            >
-              <span className="font-bold text-slate-200 text-sm">Test Results</span>
-              {openSections.tests ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-            </button>
-
-            {openSections.tests && (
-              <div className="p-6 min-h-[200px] animate-in slide-in-from-top-2 duration-200">
-                {isExecuting ? (
-                  <div className="flex flex-col items-center justify-center h-48 text-slate-500">
-                    <Loader2 className="w-8 h-8 animate-spin mb-4 text-emerald-500" />
-                    <p>코드를 실행하고 있습니다...</p>
-                  </div>
-                ) : output ? (
-                  <div className="space-y-4">
-                    <div className="flex items-center gap-3 mb-2">
-                      {output.status?.id === 3 ? (
-                        <div className="flex items-center gap-2 text-emerald-400">
-                          <CheckCircle2 className="w-5 h-5" />
-                          <span className="font-bold text-lg">테스트 통과</span>
-                        </div>
-                      ) : (
-                        <div className="flex items-center gap-2 text-red-400">
-                          <AlertCircle className="w-5 h-5" />
-                          <span className="font-bold text-lg">{output.status?.description || 'Error'}</span>
+              ) : problemError ? (
+                <div className="text-center py-12 text-red-400 text-sm">{problemError}</div>
+              ) : problem ? (
+                <>
+                  {/* 제한 정보 */}
+                  {(problem.timeLimit || problem.memoryLimit) && (
+                    <div className="flex gap-3">
+                      {problem.timeLimit && (
+                        <div className="flex items-center gap-2 text-sm text-text-muted bg-surface-subtle/60 rounded-md px-3 py-2 border border-border-subtle/50">
+                          <Clock className="w-3.5 h-3.5 text-indigo-600 dark:text-indigo-400" />
+                          <span>{problem.timeLimit}</span>
                         </div>
                       )}
-                      <div className="h-4 w-px bg-slate-700 mx-2" />
-                      <div className="text-sm text-slate-500">
-                        시간: {output.time || '0'}s • 메모리: {output.memory || '0'}KB
-                      </div>
+                      {problem.memoryLimit && (
+                        <div className="flex items-center gap-2 text-sm text-text-muted bg-surface-subtle/60 rounded-md px-3 py-2 border border-border-subtle/50">
+                          <HardDrive className="w-3.5 h-3.5 text-emerald-600 dark:text-emerald-400" />
+                          <span>{problem.memoryLimit}</span>
+                        </div>
+                      )}
                     </div>
+                  )}
 
-                    <Card className="p-4 bg-slate-900 border-slate-800">
-                      <h4 className="text-xs font-semibold text-slate-500 mb-2 uppercase">표준 출력 (Stdout)</h4>
-                      <pre className="text-sm font-mono text-slate-200 whitespace-pre-wrap">
-                        {output.stdout || <span className="text-slate-600 italic">No output</span>}
-                      </pre>
-                    </Card>
+                  {problem.description && (
+                    <section>
+                      <h3 className="text-base font-bold text-text-primary mb-2">문제</h3>
+                      <hr className="border-border-subtle mb-3" />
+                      <div className="text-text-secondary text-[15px] leading-[1.9] prose dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: problem.description }} />
+                    </section>
+                  )}
 
-                    {output.stderr && (
-                      <Card className="p-4 bg-red-900/10 border-red-500/20">
-                        <h4 className="text-xs font-semibold text-red-400 mb-2 uppercase">에러 메시지 (Stderr)</h4>
-                        <pre className="text-sm font-mono text-red-300 whitespace-pre-wrap">
-                          {output.stderr}
-                        </pre>
-                      </Card>
+                  {problem.inputDescription && (
+                    <section>
+                      <h3 className="text-base font-bold text-text-primary mb-2">입력</h3>
+                      <hr className="border-border-subtle mb-3" />
+                      <div className="text-text-secondary text-[15px] leading-[1.9] prose dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: problem.inputDescription }} />
+                    </section>
+                  )}
+
+                  {problem.outputDescription && (
+                    <section>
+                      <h3 className="text-base font-bold text-text-primary mb-2">출력</h3>
+                      <hr className="border-border-subtle mb-3" />
+                      <div className="text-text-secondary text-[15px] leading-[1.9] prose dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: problem.outputDescription }} />
+                    </section>
+                  )}
+
+                  {problem.samples.length > 0 && (
+                    <div className="space-y-3">
+                      {problem.samples.map((s) => (
+                        <div key={s.id} className="grid grid-cols-2 gap-3">
+                          <div className="bg-input-bg/80 border border-border-default rounded-lg p-3">
+                            <h4 className="text-xs font-bold text-text-faint mb-2 uppercase tracking-wider">예제 입력 {s.sampleIndex}</h4>
+                            <pre className="text-sm font-mono text-text-secondary whitespace-pre-wrap leading-relaxed">{s.input || ''}</pre>
+                          </div>
+                          <div className="bg-input-bg/80 border border-border-default rounded-lg p-3">
+                            <h4 className="text-xs font-bold text-text-faint mb-2 uppercase tracking-wider">예제 출력 {s.sampleIndex}</h4>
+                            <pre className="text-sm font-mono text-text-secondary whitespace-pre-wrap leading-relaxed">{s.output || ''}</pre>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className="text-center py-12 text-text-faint text-sm">문제를 선택해주세요.</div>
+              )}
+            </div>
+          </div>
+        </ResizablePanel>
+
+        <ResizableHandle withHandle className="bg-surface-subtle hover:bg-indigo-500/50 transition-colors w-[3px]" />
+
+        {/* ─── Right: Editor (top) + Test Results (bottom) ─── */}
+        <ResizablePanel defaultSize={62} minSize={40}>
+          <ResizablePanelGroup direction="vertical">
+            {/* Editor */}
+            <ResizablePanel defaultSize={65} minSize={30}>
+              <div className="h-full bg-surface-overlay">
+                <Editor
+                  height="100%"
+                  theme={isDark ? 'vs-dark' : 'light'}
+                  language={LANGUAGE_OPTIONS.find(l => l.value === language)?.monaco || 'javascript'}
+                  value={code}
+                  onChange={(v) => v !== undefined && setCode(v)}
+                  options={{
+                    minimap: { enabled: false },
+                    fontSize: 15,
+                    lineNumbers: 'on',
+                    roundedSelection: false,
+                    scrollBeyondLastLine: false,
+                    automaticLayout: true,
+                    padding: { top: 16 },
+                  }}
+                />
+              </div>
+            </ResizablePanel>
+
+            <ResizableHandle withHandle className="bg-surface-subtle hover:bg-indigo-500/50 transition-colors h-[3px]" />
+
+            {/* Test Results */}
+            <ResizablePanel defaultSize={35} minSize={15}>
+              <div className="h-full flex flex-col bg-page overflow-hidden">
+                <button
+                  onClick={() => setTestOpen(!testOpen)}
+                  className="flex items-center justify-between px-4 py-2 bg-surface hover:bg-hover-bg transition-colors shrink-0 border-b border-border-default"
+                >
+                  <span className="font-bold text-xs text-text-secondary uppercase tracking-wider">테스트 결과</span>
+                  {testOpen ? <ChevronDown className="w-3.5 h-3.5 text-text-faint" /> : <ChevronRight className="w-3.5 h-3.5 text-text-faint" />}
+                </button>
+
+                {testOpen && (
+                  <div className="flex-1 overflow-y-auto p-4 custom-scrollbar">
+                    {isExecuting ? (
+                      <div className="flex flex-col items-center justify-center h-full text-text-faint">
+                        <Loader2 className="w-6 h-6 animate-spin mb-3 text-emerald-500" />
+                        <p className="text-xs">실행 중...</p>
+                      </div>
+                    ) : output ? (
+                      <div className="space-y-3">
+                        <div className="flex items-center gap-3">
+                          {output.status?.id === 3 ? (
+                            <div className="flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400">
+                              <CheckCircle2 className="w-4 h-4" />
+                              <span className="font-bold text-sm">테스트 통과</span>
+                            </div>
+                          ) : (
+                            <div className="flex items-center gap-1.5 text-red-400">
+                              <AlertCircle className="w-4 h-4" />
+                              <span className="font-bold text-sm">{output.status?.description || 'Error'}</span>
+                            </div>
+                          )}
+                          <div className="h-3 w-px bg-border-subtle" />
+                          <span className="text-xs text-text-faint">
+                            {output.time || '0'}s / {output.memory || '0'}KB
+                          </span>
+                        </div>
+
+                        <Card className="p-3 bg-input-bg/80 border-border-default">
+                          <h4 className="text-[10px] font-bold text-text-faint mb-1 uppercase tracking-wider">Stdout</h4>
+                          <pre className="text-xs font-mono text-text-secondary whitespace-pre-wrap">
+                            {output.stdout || <span className="text-text-faint italic">No output</span>}
+                          </pre>
+                        </Card>
+
+                        {output.stderr && (
+                          <Card className="p-3 bg-red-50 dark:bg-red-900/10 border-red-200 dark:border-red-500/20">
+                            <h4 className="text-[10px] font-bold text-red-400 mb-1 uppercase tracking-wider">Stderr</h4>
+                            <pre className="text-xs font-mono text-red-600 dark:text-red-300 whitespace-pre-wrap">{output.stderr}</pre>
+                          </Card>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="flex flex-col items-center justify-center h-full text-text-faint">
+                        <Play className="w-8 h-8 mb-2 opacity-15" />
+                        <p className="text-xs">코드를 실행하여 결과를 확인하세요.</p>
+                      </div>
                     )}
-                  </div>
-                ) : (
-                  <div className="flex flex-col items-center justify-center h-48 text-slate-600">
-                    <Play className="w-12 h-12 mb-4 opacity-20" />
-                    <p>코드를 실행하여 결과를 확인하세요.</p>
                   </div>
                 )}
               </div>
-            )}
-          </div>
-        </div>
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        </ResizablePanel>
+      </ResizablePanelGroup>
 
-        {/* Right Panel: Monaco Editor */}
-        <div className="flex-1 flex flex-col bg-[#1e1e1e]">
-          <div className="flex-1 relative">
-            <Editor
-              height="100%"
-              theme="vs-dark"
-              language={LANGUAGE_OPTIONS.find(l => l.value === language)?.monaco || 'javascript'}
-              value={code}
-              onChange={handleEditorChange}
-              options={{
-                minimap: { enabled: false },
-                fontSize: 14,
-                lineNumbers: 'on',
-                roundedSelection: false,
-                scrollBeyondLastLine: false,
-                readOnly: false,
-                automaticLayout: true,
-                padding: { top: 16 }
-              }}
-            />
-          </div>
-
-          {/* Footer Actions */}
-          <div className="h-14 border-t border-slate-800 bg-[#0F1117] px-4 flex items-center justify-between">
-            <Button variant="ghost" size="sm" className="text-slate-400 hover:text-slate-200">
-              <Plus className="w-4 h-4 mr-2" /> Add Test Case
-            </Button>
-
-            <div className="flex items-center gap-2">
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => navigate(`/problems/1000/solutions`)}
-                className="bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
-              >
-                <Code2 className="w-4 h-4 mr-2" /> 풀이 보기
-              </Button>
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={executeCode}
-                disabled={isExecuting}
-                className="w-24"
-              >
-                {isExecuting ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Run Code'}
-              </Button>
-              <Button
-                className="bg-emerald-600 hover:bg-emerald-700 text-white w-24"
-                size="sm"
-                onClick={handleSubmit}
-                disabled={isSubmitting || isExecuting}
-              >
-                {isSubmitting ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Submit'}
-              </Button>
-            </div>
-          </div>
+      {/* ─── Bottom Action Bar (고정) ─── */}
+      <div className="h-14 border-t border-border-default bg-surface px-5 flex items-center justify-between shrink-0">
+        <Button variant="ghost" className="text-text-secondary hover:text-text-primary hover:bg-hover-bg text-sm border border-border-subtle px-3 py-1.5">
+          <Plus className="w-4 h-4 mr-1.5" /> 테스트 추가
+        </Button>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="secondary"
+            onClick={() => navigate(`/problems/${problemId || '1000'}/solutions`)}
+            className="bg-surface-subtle hover:bg-border-subtle text-text-secondary border border-border-subtle text-sm px-4 py-2"
+          >
+            <Code2 className="w-4 h-4 mr-1.5" /> 풀이 보기
+          </Button>
+          <Button
+            variant="primary"
+            onClick={executeCode}
+            disabled={isExecuting}
+            className="text-sm px-5 py-2"
+          >
+            {isExecuting ? <Loader2 className="w-4 h-4 animate-spin" /> : <><Play className="w-4 h-4 mr-1.5" />실행</>}
+          </Button>
+          <Button
+            className="bg-emerald-600 hover:bg-emerald-700 text-white text-sm px-5 py-2 font-semibold"
+            onClick={handleSubmit}
+            disabled={isSubmitting || isExecuting}
+          >
+            {isSubmitting ? <Loader2 className="w-4 h-4 animate-spin" /> : '제출'}
+          </Button>
         </div>
       </div>
     </div>

--- a/src/features/problems/ProblemList.tsx
+++ b/src/features/problems/ProblemList.tsx
@@ -180,15 +180,15 @@ export const ProblemList = () => {
   };
 
   const getTierColor = (tier: string | null) => {
-    if (!tier) return 'text-slate-500 bg-slate-500/10 border-slate-500/20';
+    if (!tier) return 'text-text-faint bg-surface-subtle border-border-subtle';
     const t = tier.toLowerCase();
-    if (t.includes('gold')) return 'text-yellow-500 bg-yellow-500/10 border-yellow-500/20';
-    if (t.includes('silver')) return 'text-slate-300 bg-slate-400/10 border-slate-400/20';
-    if (t.includes('bronze')) return 'text-amber-700 bg-amber-700/10 border-amber-700/20';
-    if (t.includes('platinum')) return 'text-cyan-400 bg-cyan-400/10 border-cyan-400/20';
-    if (t.includes('diamond')) return 'text-blue-400 bg-blue-400/10 border-blue-400/20';
-    if (t.includes('ruby')) return 'text-red-400 bg-red-400/10 border-red-400/20';
-    return 'text-emerald-500 bg-emerald-500/10 border-emerald-500/20';
+    if (t.includes('gold')) return 'text-yellow-600 dark:text-yellow-400 bg-yellow-500/10 border-yellow-500/20';
+    if (t.includes('silver')) return 'text-text-secondary bg-surface-subtle border-border-subtle';
+    if (t.includes('bronze')) return 'text-amber-700 dark:text-amber-500 bg-amber-500/10 border-amber-500/20';
+    if (t.includes('platinum')) return 'text-cyan-600 dark:text-cyan-400 bg-cyan-500/10 border-cyan-500/20';
+    if (t.includes('diamond')) return 'text-blue-600 dark:text-blue-400 bg-blue-500/10 border-blue-500/20';
+    if (t.includes('ruby')) return 'text-red-600 dark:text-red-400 bg-red-500/10 border-red-500/20';
+    return 'text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 border-emerald-500/20';
   };
 
   // Create Box
@@ -286,14 +286,14 @@ export const ProblemList = () => {
   // ─── View: Problem Box List ───
   if (!currentBox) {
     return (
-      <div className="flex-1 overflow-y-auto bg-[#0a0c10] p-8 pb-12 font-sans text-slate-100 relative">
+      <div className="flex-1 overflow-y-auto bg-page p-8 pb-12 font-sans text-text-primary relative">
         <div className="max-w-6xl mx-auto space-y-10">
 
           {/* 헤더 */}
-          <div className="border-b border-slate-800 pb-8 mt-2 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+          <div className="border-b border-border-default pb-8 mt-2 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
             <div className="flex-1">
-              <h1 className="text-4xl font-extrabold text-white tracking-tight mb-3">나의 문제집</h1>
-              <p className="text-base text-slate-400 font-medium leading-relaxed max-w-3xl">
+              <h1 className="text-4xl font-extrabold text-text-primary tracking-tight mb-3">나의 문제집</h1>
+              <p className="text-base text-text-muted font-medium leading-relaxed max-w-3xl">
                 풀고 싶은 문제들을 테마별 그룹으로 분류하여 체계적으로 학습하고 관리해보세요.
               </p>
             </div>
@@ -308,7 +308,7 @@ export const ProblemList = () => {
           {/* 로딩 */}
           {loading && (
             <div className="flex justify-center py-20">
-              <Loader2 className="w-8 h-8 text-slate-500 animate-spin" />
+              <Loader2 className="w-8 h-8 text-text-faint animate-spin" />
             </div>
           )}
 
@@ -328,16 +328,16 @@ export const ProblemList = () => {
                 <Card
                   key={box.id}
                   onClick={() => handleOpenBox(box)}
-                  className="group bg-[#151922] border-slate-800 p-6 cursor-pointer hover:border-slate-600 transition-all shadow-md flex flex-col min-h-[180px]"
+                  className="group bg-surface-raised border-border-default p-6 cursor-pointer hover:border-border-subtle transition-all shadow-md flex flex-col min-h-[180px]"
                 >
                   {/* 상단: 제목 + 더보기 메뉴 */}
                   <div className="flex items-start justify-between gap-2 mb-3">
-                    <h3 className="text-xl font-bold text-slate-200 group-hover:text-white line-clamp-1 flex-1">{box.title}</h3>
+                    <h3 className="text-xl font-bold text-text-secondary group-hover:text-text-primary line-clamp-1 flex-1">{box.title}</h3>
                     {canManage && (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <button
-                          className="text-slate-500 hover:text-slate-300 transition-colors p-1 shrink-0 -mr-1 -mt-1"
+                          className="text-text-faint hover:text-text-secondary transition-colors p-1 shrink-0 -mr-1 -mt-1"
                           onClick={(e) => e.stopPropagation()}
                         >
                           <MoreVertical className="w-5 h-5" />
@@ -371,7 +371,7 @@ export const ProblemList = () => {
                   </div>
 
                   {/* 하단: 상대 시간 */}
-                  <div className="flex items-center text-xs text-slate-500 mt-auto pt-4 border-t border-slate-800/50">
+                  <div className="flex items-center text-xs text-text-faint mt-auto pt-4 border-t border-border-default/50">
                     <span className="font-medium">{relativeTime(box.updatedAt)} 업데이트</span>
                   </div>
                 </Card>
@@ -381,9 +381,9 @@ export const ProblemList = () => {
               {boxes.length === 0 && (
                 <button
                   onClick={() => setIsCreateModalOpen(true)}
-                  className="border-2 border-dashed border-slate-800 rounded-xl p-6 flex flex-col items-center justify-center gap-4 text-slate-500 hover:text-indigo-400 hover:border-indigo-500/50 hover:bg-indigo-500/5 transition-all min-h-[180px]"
+                  className="border-2 border-dashed border-border-default rounded-xl p-6 flex flex-col items-center justify-center gap-4 text-text-faint hover:text-indigo-600 dark:hover:text-indigo-400 hover:border-indigo-500/50 hover:bg-indigo-500/5 transition-all min-h-[180px]"
                 >
-                  <div className="w-12 h-12 rounded-full bg-[#1b202c] border border-slate-800 flex items-center justify-center transition-all shadow-inner">
+                  <div className="w-12 h-12 rounded-full bg-surface-inset border border-border-default flex items-center justify-center transition-all shadow-inner">
                     <Plus className="w-6 h-6" />
                   </div>
                   <span className="font-bold text-sm">첫 문제집 만들기</span>
@@ -398,7 +398,7 @@ export const ProblemList = () => {
                   <button
                     onClick={() => setBoxPage(p => Math.max(0, p - 1))}
                     disabled={boxPage === 0}
-                    className="p-2 text-slate-400 hover:text-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    className="p-2 text-text-muted hover:text-text-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
                   >
                     <ChevronLeft className="w-4 h-4" />
                   </button>
@@ -409,7 +409,7 @@ export const ProblemList = () => {
                       className={`w-8 h-8 rounded-lg text-xs font-bold transition-colors ${
                         boxPage === i
                           ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/50'
-                          : 'text-slate-500 hover:bg-slate-800 hover:text-slate-300'
+                          : 'text-text-faint hover:bg-surface-subtle hover:text-text-secondary'
                       }`}
                     >
                       {i + 1}
@@ -418,7 +418,7 @@ export const ProblemList = () => {
                   <button
                     onClick={() => setBoxPage(p => Math.min(boxTotalPages - 1, p + 1))}
                     disabled={boxPage >= boxTotalPages - 1}
-                    className="p-2 text-slate-400 hover:text-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    className="p-2 text-text-muted hover:text-text-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
                   >
                     <ChevronRight className="w-4 h-4" />
                   </button>
@@ -433,23 +433,23 @@ export const ProblemList = () => {
         <Modal isOpen={isCreateModalOpen} onClose={() => { setIsCreateModalOpen(false); setCreateError(''); }} title="새 문제집 만들기">
           <form onSubmit={handleCreateBox} className="space-y-4">
             <div className="space-y-1">
-              <label className="text-sm font-medium text-slate-400">문제집 이름</label>
+              <label className="text-sm font-medium text-text-muted">문제집 이름</label>
               <input
                 type="text"
                 required
                 value={newBox.title}
                 onChange={(e) => setNewBox({ ...newBox, title: e.target.value })}
                 placeholder="예: 코딩테스트 대비 100제"
-                className="w-full bg-slate-900 border border-slate-800 rounded-lg px-4 py-2.5 text-slate-200 focus:outline-none focus:border-emerald-500"
+                className="w-full bg-input-bg border border-border-default rounded-lg px-4 py-2.5 text-text-secondary focus:outline-none focus:border-emerald-500"
               />
             </div>
             <div className="space-y-1">
-              <label className="text-sm font-medium text-slate-400">설명</label>
+              <label className="text-sm font-medium text-text-muted">설명</label>
               <textarea
                 value={newBox.description}
                 onChange={(e) => setNewBox({ ...newBox, description: e.target.value })}
                 placeholder="문제집에 대한 설명을 적어주세요."
-                className="w-full bg-slate-900 border border-slate-800 rounded-lg px-4 py-2.5 text-slate-200 focus:outline-none focus:border-emerald-500 min-h-[80px]"
+                className="w-full bg-input-bg border border-border-default rounded-lg px-4 py-2.5 text-text-secondary focus:outline-none focus:border-emerald-500 min-h-[80px]"
               />
             </div>
             {createError && (
@@ -471,23 +471,23 @@ export const ProblemList = () => {
         <Modal isOpen={!!editTarget} onClose={() => { setEditTarget(null); setEditError(''); }} title="문제집 수정">
           <form onSubmit={handleEditBox} className="space-y-4">
             <div className="space-y-1">
-              <label className="text-sm font-medium text-slate-400">문제집 이름</label>
+              <label className="text-sm font-medium text-text-muted">문제집 이름</label>
               <input
                 type="text"
                 required
                 value={editTarget?.title || ''}
                 onChange={(e) => setEditTarget(prev => prev ? { ...prev, title: e.target.value } : prev)}
                 placeholder="문제집 이름"
-                className="w-full bg-slate-900 border border-slate-800 rounded-lg px-4 py-2.5 text-slate-200 focus:outline-none focus:border-emerald-500"
+                className="w-full bg-input-bg border border-border-default rounded-lg px-4 py-2.5 text-text-secondary focus:outline-none focus:border-emerald-500"
               />
             </div>
             <div className="space-y-1">
-              <label className="text-sm font-medium text-slate-400">설명</label>
+              <label className="text-sm font-medium text-text-muted">설명</label>
               <textarea
                 value={editTarget?.description || ''}
                 onChange={(e) => setEditTarget(prev => prev ? { ...prev, description: e.target.value } : prev)}
                 placeholder="문제집에 대한 설명을 적어주세요."
-                className="w-full bg-slate-900 border border-slate-800 rounded-lg px-4 py-2.5 text-slate-200 focus:outline-none focus:border-emerald-500 min-h-[80px]"
+                className="w-full bg-input-bg border border-border-default rounded-lg px-4 py-2.5 text-text-secondary focus:outline-none focus:border-emerald-500 min-h-[80px]"
               />
             </div>
             {editError && (
@@ -510,27 +510,27 @@ export const ProblemList = () => {
 
   // ─── View: Problems Inside a Box ───
   return (
-    <div className="flex-1 overflow-y-auto bg-[#0a0c10] p-8 pb-12 font-sans text-slate-100 relative">
+    <div className="flex-1 overflow-y-auto bg-page p-8 pb-12 font-sans text-text-primary relative">
       <div className="max-w-6xl mx-auto space-y-8">
 
         {/* Navigation & Header */}
         <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-2 text-sm text-slate-500 font-medium tracking-wide">
-            <button onClick={() => setCurrentBox(null)} className="hover:text-slate-300 transition-colors">문제집</button>
-            <span className="text-slate-700">/</span>
-            <span className="text-slate-300 font-semibold">{currentBox.title}</span>
+          <div className="flex items-center gap-2 text-sm text-text-faint font-medium tracking-wide">
+            <button onClick={() => setCurrentBox(null)} className="hover:text-text-secondary transition-colors">문제집</button>
+            <span className="text-text-faint">/</span>
+            <span className="text-text-secondary font-semibold">{currentBox.title}</span>
           </div>
 
-          <div className="border-b border-slate-800 pb-8 mt-4">
+          <div className="border-b border-border-default pb-8 mt-4">
             <div className="flex justify-between items-center gap-4">
               <div className="flex items-center gap-4">
                 <button
                   onClick={() => setCurrentBox(null)}
-                  className="p-2 -ml-2 text-slate-400 hover:text-white rounded-lg hover:bg-slate-800 transition-all"
+                  className="p-2 -ml-2 text-text-muted hover:text-text-primary rounded-lg hover:bg-surface-subtle transition-all"
                 >
                   <ArrowLeft className="w-6 h-6" />
                 </button>
-                <h1 className="text-3xl font-extrabold text-white tracking-tight">{currentBox.title}</h1>
+                <h1 className="text-3xl font-extrabold text-text-primary tracking-tight">{currentBox.title}</h1>
               </div>
               <Button
                 className="bg-emerald-600 border border-emerald-500 text-white font-bold hover:bg-emerald-700 shrink-0 shadow-sm transition-all"
@@ -540,7 +540,7 @@ export const ProblemList = () => {
               </Button>
             </div>
             {currentBox.description && (
-              <p className="text-slate-400 text-sm mt-4 leading-relaxed">{currentBox.description}</p>
+              <p className="text-text-muted text-sm mt-4 leading-relaxed">{currentBox.description}</p>
             )}
           </div>
         </div>
@@ -548,11 +548,11 @@ export const ProblemList = () => {
         {/* Search & Filter Bar */}
         <div className="flex gap-4">
           <div className="flex-1 relative">
-            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-500" />
+            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-faint" />
             <input
               type="text"
               placeholder="문제 검색..."
-              className="w-full h-12 bg-[#151922] border border-slate-800 rounded-xl pl-12 pr-4 text-slate-200 placeholder:text-slate-500 focus:outline-none focus:border-emerald-500 transition-all shadow-sm"
+              className="w-full h-12 bg-surface-raised border border-border-default rounded-xl pl-12 pr-4 text-text-secondary placeholder:text-text-faint focus:outline-none focus:border-emerald-500 transition-all shadow-sm"
             />
           </div>
         </div>
@@ -560,21 +560,21 @@ export const ProblemList = () => {
         {/* Problem List */}
         {problemsLoading ? (
           <div className="flex justify-center py-20">
-            <Loader2 className="w-8 h-8 text-slate-500 animate-spin" />
+            <Loader2 className="w-8 h-8 text-text-faint animate-spin" />
           </div>
         ) : problems.length === 0 ? (
           <div className="text-center py-20">
-            <p className="text-slate-500 mb-4">아직 등록된 문제가 없습니다.</p>
+            <p className="text-text-faint mb-4">아직 등록된 문제가 없습니다.</p>
             <Button onClick={() => toWs('problems/new')} className="bg-emerald-600 hover:bg-emerald-700 text-white font-bold">
               <Plus className="w-4 h-4 mr-1" /> 첫 문제 등록하기
             </Button>
           </div>
         ) : (
           <>
-          <Card className="bg-[#151922] border-slate-800 overflow-hidden shadow-md">
+          <Card className="bg-surface-raised border-border-default overflow-hidden shadow-md">
             <div className="overflow-x-auto">
               <div className="min-w-[700px]">
-                <div className="grid grid-cols-[80px_1fr_120px_120px_80px] gap-4 p-4 border-b border-slate-800 bg-[#0f1117] text-sm font-bold text-slate-400">
+                <div className="grid grid-cols-[80px_1fr_120px_120px_80px] gap-4 p-4 border-b border-border-default bg-page text-sm font-bold text-text-muted">
                   <div className="text-center">번호</div>
                   <div>제목</div>
                   <div>티어</div>
@@ -582,16 +582,16 @@ export const ProblemList = () => {
                   {canManage && <div></div>}
                 </div>
 
-                <div className="divide-y divide-slate-800/50">
+                <div className="divide-y divide-border-default">
                   {problems.map((p) => (
                     <div
                       key={p.id}
-                      onClick={() => navigate(`/ide/${p.problemNumber}`)}
-                      className="grid grid-cols-[80px_1fr_120px_120px_80px] gap-4 p-4 items-center hover:bg-slate-800/40 transition-colors cursor-pointer group"
+                      onClick={() => navigate(`/ws/${currentWsId}/ide/${p.problemNumber}`)}
+                      className="grid grid-cols-[80px_1fr_120px_120px_80px] gap-4 p-4 items-center hover:bg-hover-bg transition-colors cursor-pointer group"
                     >
-                      <div className="text-center text-slate-500 font-mono text-xs">{p.problemNumber}</div>
+                      <div className="text-center text-emerald-600 dark:text-emerald-400 font-mono text-sm font-bold">{p.problemNumber}</div>
                       <div className="flex items-center gap-3">
-                        <span className="text-slate-200 font-bold group-hover:text-emerald-400 transition-colors">{p.title}</span>
+                        <span className="text-text-secondary font-bold group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors">{p.title}</span>
                       </div>
                       <div>
                         {p.tier ? (
@@ -599,10 +599,10 @@ export const ProblemList = () => {
                             {p.tier}
                           </span>
                         ) : (
-                          <span className="text-slate-600 text-xs">-</span>
+                          <span className="text-text-faint text-xs">-</span>
                         )}
                       </div>
-                      <div className="text-slate-400 text-xs">
+                      <div className="text-text-muted text-xs">
                         {p.deadline ? new Date(p.deadline).toLocaleDateString('ko-KR') : '-'}
                       </div>
                       {canManage && (
@@ -610,7 +610,7 @@ export const ProblemList = () => {
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <button
-                                className="text-slate-600 hover:text-slate-300 hover:bg-slate-700/50 rounded-lg transition-colors p-2"
+                                className="text-text-faint hover:text-text-secondary hover:bg-hover-bg rounded-lg transition-colors p-2"
                                 onClick={(e) => e.stopPropagation()}
                               >
                                 <MoreVertical className="w-4 h-4" />
@@ -654,7 +654,7 @@ export const ProblemList = () => {
                 <button
                   onClick={() => setProblemPage(p => Math.max(0, p - 1))}
                   disabled={problemPage === 0}
-                  className="p-2 text-slate-400 hover:text-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                  className="p-2 text-text-muted hover:text-text-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
                 >
                   <ChevronLeft className="w-4 h-4" />
                 </button>
@@ -665,7 +665,7 @@ export const ProblemList = () => {
                     className={`w-8 h-8 rounded-lg text-xs font-bold transition-colors ${
                       problemPage === i
                         ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/50'
-                        : 'text-slate-500 hover:bg-slate-800 hover:text-slate-300'
+                        : 'text-text-faint hover:bg-surface-subtle hover:text-text-secondary'
                     }`}
                   >
                     {i + 1}
@@ -674,7 +674,7 @@ export const ProblemList = () => {
                 <button
                   onClick={() => setProblemPage(p => Math.min(problemTotalPages - 1, p + 1))}
                   disabled={problemPage >= problemTotalPages - 1}
-                  className="p-2 text-slate-400 hover:text-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                  className="p-2 text-text-muted hover:text-text-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
                 >
                   <ChevronRight className="w-4 h-4" />
                 </button>
@@ -688,14 +688,14 @@ export const ProblemList = () => {
       {/* 문제 수정 모달 */}
       <Modal isOpen={!!editProblemTarget} onClose={closeEditProblemModal} title="문제 수정">
         <div className="space-y-6">
-          <div className="flex items-center gap-3 bg-slate-800/50 rounded-lg px-4 py-3">
-            <span className="text-xs font-bold text-slate-400 bg-slate-700/60 rounded px-2 py-1 font-mono">{editProblemTarget?.problemNumber}</span>
-            <span className="text-base font-bold text-slate-200">{editProblemTarget?.title}</span>
+          <div className="flex items-center gap-3 bg-surface-subtle/50 rounded-lg px-4 py-3">
+            <span className="text-xs font-bold text-text-muted bg-surface-subtle rounded px-2 py-1 font-mono">{editProblemTarget?.problemNumber}</span>
+            <span className="text-base font-bold text-text-secondary">{editProblemTarget?.title}</span>
           </div>
 
           {/* 마감일 */}
           <div className="space-y-2">
-            <label className="text-sm font-bold text-slate-400">마감일</label>
+            <label className="text-sm font-bold text-text-muted">마감일</label>
             <div className="relative">
               <DateTimePicker
                 value={editDeadline}
@@ -710,7 +710,7 @@ export const ProblemList = () => {
                 } : undefined}
               />
               {!editDeadline && (
-                <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-500 pointer-events-none text-sm">
+                <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-text-faint pointer-events-none text-sm">
                   마감일을 선택하세요
                 </span>
               )}
@@ -725,7 +725,7 @@ export const ProblemList = () => {
                 onCheckedChange={setEditReminderEnabled}
                 disabled={!editDeadline}
               />
-              <label className="text-sm text-slate-300">마감 전 알림</label>
+              <label className="text-sm text-text-secondary">마감 전 알림</label>
             </div>
 
             {editReminderEnabled && editDeadline && (
@@ -733,7 +733,7 @@ export const ProblemList = () => {
                 value={String(editReminderHours)}
                 onValueChange={(v) => setEditReminderHours(Number(v))}
               >
-                <SelectTrigger className="w-40 bg-slate-900 border-slate-800">
+                <SelectTrigger className="w-40 bg-input-bg border-border-default">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/features/problems/ProblemRegistration.tsx
+++ b/src/features/problems/ProblemRegistration.tsx
@@ -157,16 +157,16 @@ export const ProblemRegistration = () => {
   const isProcessing = flowStatus === 'loading' || flowStatus === 'crawling' || flowStatus === 'registering';
 
   return (
-    <div className="flex-1 overflow-y-auto bg-[#0F1117] p-8 pb-24">
+    <div className="flex-1 overflow-y-auto bg-page p-8 pb-24">
       <div className="max-w-5xl mx-auto space-y-6">
 
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-xl font-bold text-slate-100">문제 등록</h1>
+            <h1 className="text-xl font-bold text-text-primary">문제 등록</h1>
             {currentBox && (
-              <p className="text-sm text-slate-500 mt-1">
-                <span className="text-slate-400 font-medium">{currentBox.title}</span>에 문제 추가
+              <p className="text-sm text-text-faint mt-1">
+                <span className="text-text-muted font-medium">{currentBox.title}</span>에 문제 추가
               </p>
             )}
           </div>
@@ -175,11 +175,11 @@ export const ProblemRegistration = () => {
           </Button>
         </div>
 
-        <div className="bg-[#141820] border border-slate-800 rounded-xl p-8 space-y-8">
+        <div className="bg-surface border border-border-default rounded-xl p-8 space-y-8">
 
           {/* 문제 번호 입력 */}
           <div className="space-y-2">
-            <label className="text-sm font-bold text-slate-400">백준 문제 번호</label>
+            <label className="text-sm font-bold text-text-muted">백준 문제 번호</label>
             <div className="flex gap-2">
               <input
                 type="text"
@@ -193,7 +193,7 @@ export const ProblemRegistration = () => {
                 }}
                 onKeyDown={handleKeyDown}
                 placeholder="예: 2504"
-                className="flex-1 bg-slate-900 border border-slate-800 rounded-lg px-4 py-3 text-slate-200 focus:outline-none focus:border-indigo-500"
+                className="flex-1 bg-input-bg border border-border-default rounded-lg px-4 py-3 text-text-secondary focus:outline-none focus:border-indigo-500"
               />
               <Button
                 onClick={handleLookup}
@@ -209,13 +209,13 @@ export const ProblemRegistration = () => {
             {/* 상태 메시지 */}
             <div className="min-h-[20px]">
               {flowStatus === 'loading' && (
-                <span className="text-slate-400 text-sm flex items-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> 조회 중...</span>
+                <span className="text-text-muted text-sm flex items-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> 조회 중...</span>
               )}
               {flowStatus === 'crawling' && (
-                <span className="text-yellow-400 text-sm flex items-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> 백준에서 문제를 수집하고 있습니다...</span>
+                <span className="text-yellow-600 dark:text-yellow-400 text-sm flex items-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> 백준에서 문제를 수집하고 있습니다...</span>
               )}
               {flowStatus === 'registering' && (
-                <span className="text-indigo-400 text-sm flex items-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> 문제집에 등록 중...</span>
+                <span className="text-indigo-600 dark:text-indigo-400 text-sm flex items-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> 문제집에 등록 중...</span>
               )}
               {flowStatus === 'found' && (
                 <span className="text-green-400 text-sm flex items-center gap-2"><CheckCircle2 className="w-4 h-4" /> 문제를 찾았습니다</span>
@@ -231,25 +231,25 @@ export const ProblemRegistration = () => {
 
           {/* 문제 정보 미리보기 */}
           <div className="space-y-2">
-            <label className="text-sm font-bold text-slate-400">문제 제목</label>
-            <div className="w-full bg-slate-900 border border-slate-800 rounded-lg px-4 py-3 text-slate-200 min-h-[48px]">
-              {problem?.title || <span className="text-slate-600">문제 번호를 조회하면 자동으로 채워집니다</span>}
+            <label className="text-sm font-bold text-text-muted">문제 제목</label>
+            <div className="w-full bg-input-bg border border-border-default rounded-lg px-4 py-3 text-text-secondary min-h-[48px]">
+              {problem?.title || <span className="text-text-faint">문제 번호를 조회하면 자동으로 채워집니다</span>}
             </div>
           </div>
 
           <div className="grid grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-bold text-slate-400">티어</label>
-              <div className="w-full bg-slate-900 border border-slate-800 rounded-lg px-4 py-3 text-slate-200 min-h-[48px]">
-                {problem?.tier || <span className="text-slate-600">-</span>}
+              <label className="text-sm font-bold text-text-muted">티어</label>
+              <div className="w-full bg-input-bg border border-border-default rounded-lg px-4 py-3 text-text-secondary min-h-[48px]">
+                {problem?.tier || <span className="text-text-faint">-</span>}
               </div>
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-bold text-slate-400">태그</label>
-              <div className="w-full bg-slate-900 border border-slate-800 rounded-lg px-4 py-3 min-h-[48px]">
+              <label className="text-sm font-bold text-text-muted">태그</label>
+              <div className="w-full bg-input-bg border border-border-default rounded-lg px-4 py-3 min-h-[48px]">
                 {tags
-                  ? <span className="text-slate-200">{tags}</span>
-                  : <span className="text-slate-600">문제 번호를 조회하면 자동으로 채워집니다</span>}
+                  ? <span className="text-text-secondary">{tags}</span>
+                  : <span className="text-text-faint">문제 번호를 조회하면 자동으로 채워집니다</span>}
               </div>
             </div>
           </div>
@@ -257,7 +257,7 @@ export const ProblemRegistration = () => {
           {/* 마감일 & 알림 */}
           <div className="space-y-4">
             <div className="space-y-2">
-              <label className="text-sm font-bold text-slate-400">마감일</label>
+              <label className="text-sm font-bold text-text-muted">마감일</label>
               <div className="relative">
                 <DateTimePicker
                   value={deadline}
@@ -273,7 +273,7 @@ export const ProblemRegistration = () => {
                   } : undefined}
                 />
                 {!deadline && (
-                  <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-500 pointer-events-none text-sm">
+                  <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-text-faint pointer-events-none text-sm">
                     마감일을 선택하세요
                   </span>
                 )}
@@ -287,7 +287,7 @@ export const ProblemRegistration = () => {
                   onCheckedChange={setReminderEnabled}
                   disabled={!deadline}
                 />
-                <label className="text-sm text-slate-300">마감 전 알림</label>
+                <label className="text-sm text-text-secondary">마감 전 알림</label>
               </div>
 
               {reminderEnabled && deadline && (
@@ -295,7 +295,7 @@ export const ProblemRegistration = () => {
                   value={String(reminderHours)}
                   onValueChange={(v) => setReminderHours(Number(v))}
                 >
-                  <SelectTrigger className="w-40 bg-slate-900 border-slate-800">
+                  <SelectTrigger className="w-40 bg-input-bg border-border-default">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>

--- a/src/features/problems/ProblemSolutions.tsx
+++ b/src/features/problems/ProblemSolutions.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useWorkspaceNavigate } from '@/hooks/useWorkspaceNavigate';
 import { Card, Button, Badge } from '@/components/ui/Base';
 import {
   ThumbsUp,
@@ -12,9 +13,11 @@ import {
   History
 } from 'lucide-react';
 import Editor from '@monaco-editor/react';
+import { useIsDark } from '@/App';
 
 export const ProblemSolutions = () => {
-  const navigate = useNavigate();
+  const { navigate, toWs } = useWorkspaceNavigate();
+  const isDark = useIsDark();
   const { id } = useParams();
   const [activeSolutionId, setActiveSolutionId] = useState(1);
   const [currentVersionIndex, setCurrentVersionIndex] = useState(0);
@@ -143,23 +146,23 @@ int main() {
   };
 
   return (
-    <div className="flex h-full bg-[#0F1117]">
+    <div className="flex h-full bg-page">
       {/* Sidebar: Solutions List for Selected Problem */}
-      <div className="w-80 bg-[#0F1117] border-r border-slate-800 flex flex-col">
-        <div className="p-4 border-b border-slate-800 flex items-center gap-2">
-          <Button variant="ghost" size="sm" onClick={() => navigate(`/ide/${id || '1000'}`)} className="-ml-2 text-slate-400 hover:text-white">
+      <div className="w-80 bg-page border-r border-border-subtle flex flex-col">
+        <div className="p-4 border-b border-border-default flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={() => toWs(`ide/${id || '1000'}`)} className="-ml-2 text-text-muted hover:text-text-primary">
             <ArrowLeft className="w-4 h-4 mr-2" /> 문제로 돌아가기
           </Button>
         </div>
-        <div className="p-4 border-b border-slate-800 bg-[#141820]">
-          <h2 className="font-bold text-slate-200">1000. A+B 풀이</h2>
-          <p className="text-xs text-slate-500 mt-1">총 152개의 풀이가 있습니다.</p>
+        <div className="p-4 border-b border-border-default bg-surface">
+          <h2 className="font-bold text-text-secondary">1000. A+B 풀이</h2>
+          <p className="text-xs text-text-faint mt-1">총 152개의 풀이가 있습니다.</p>
         </div>
-        <div className="p-4 border-b border-slate-800">
+        <div className="p-4 border-b border-border-default">
           <input
             type="text"
             placeholder="언어, 작성자 검색"
-            className="w-full h-9 bg-slate-900 border border-slate-800 rounded-lg pl-3 pr-3 text-sm text-slate-200 focus:outline-none focus:border-emerald-500"
+            className="w-full h-9 bg-input-bg border border-border-default rounded-lg pl-3 pr-3 text-sm text-text-secondary focus:outline-none focus:border-emerald-500"
           />
         </div>
         <div className="flex-1 overflow-y-auto">
@@ -167,17 +170,17 @@ int main() {
             <div
               key={sol.id}
               onClick={() => handleSolutionChange(sol.id)}
-              className={`p-4 border-b border-slate-800/50 cursor-pointer transition-all hover:bg-slate-800/30 ${sol.id === activeSolutionId ? 'bg-slate-800/40 border-l-4 border-l-emerald-500' : 'border-l-4 border-l-transparent'
+              className={`p-4 border-b border-border-default/50 cursor-pointer transition-all hover:bg-hover-bg ${sol.id === activeSolutionId ? 'bg-surface-subtle/40 border-l-4 border-l-emerald-500' : 'border-l-4 border-l-transparent'
                 }`}
             >
               <div className="flex justify-between items-start mb-1">
                 <Badge className="text-[10px] px-1.5 py-0.5">{sol.lang}</Badge>
-                <span className="text-[10px] text-slate-500">{sol.time}</span>
+                <span className="text-[10px] text-text-faint">{sol.time}</span>
               </div>
-              <h3 className={`font-semibold text-sm mb-2 line-clamp-2 ${sol.id === activeSolutionId ? 'text-emerald-400' : 'text-slate-300'}`}>
+              <h3 className={`font-semibold text-sm mb-2 line-clamp-2 ${sol.id === activeSolutionId ? 'text-emerald-400' : 'text-text-secondary'}`}>
                 {sol.title}
               </h3>
-              <div className="flex items-center justify-between text-xs text-slate-500">
+              <div className="flex items-center justify-between text-xs text-text-faint">
                 <span>{sol.user}</span>
                 <div className="flex items-center gap-2">
                   <span className="flex items-center gap-0.5"><ThumbsUp className="w-3 h-3" /> {sol.likes}</span>
@@ -192,12 +195,12 @@ int main() {
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 flex flex-col min-w-0 bg-[#0F1117]">
+      <div className="flex-1 flex flex-col min-w-0 bg-page">
         {/* Header */}
-        <div className="h-16 px-6 border-b border-slate-800 flex items-center justify-between bg-[#0F1117]">
+        <div className="h-16 px-6 border-b border-border-default flex items-center justify-between bg-page">
           <div>
-            <h1 className="text-lg font-bold text-slate-100">{activeSolution.title}</h1>
-            <div className="flex items-center gap-3 text-xs text-slate-500 mt-1">
+            <h1 className="text-lg font-bold text-text-primary">{activeSolution.title}</h1>
+            <div className="flex items-center gap-3 text-xs text-text-faint mt-1">
               <span className="flex items-center gap-1"><Calendar className="w-3 h-3" /> {activeSolution.time}</span>
               <span className="flex items-center gap-1"><Eye className="w-3 h-3" /> {activeSolution.views}</span>
             </div>
@@ -210,25 +213,25 @@ int main() {
         </div>
 
         {/* Code Version Controller */}
-        <div className="h-10 border-b border-slate-800 bg-[#1e1e1e] flex items-center justify-between px-4">
-          <div className="flex items-center gap-2 text-xs text-slate-400">
+        <div className="h-10 border-b border-border-default bg-surface-overlay flex items-center justify-between px-4">
+          <div className="flex items-center gap-2 text-xs text-text-muted">
             <History className="w-3.5 h-3.5" />
             <span>제출 기록 (Version {totalVersions - currentVersionIndex} / {totalVersions})</span>
-            <span className="text-slate-600 ml-2">{activeVersion.timestamp}</span>
+            <span className="text-text-faint ml-2">{activeVersion.timestamp}</span>
           </div>
 
           <div className="flex items-center gap-1">
             <button
               onClick={handlePrevVersion}
               disabled={currentVersionIndex >= totalVersions - 1}
-              className="p-1 rounded hover:bg-slate-700 text-slate-400 disabled:opacity-30 disabled:hover:bg-transparent"
+              className="p-1 rounded hover:bg-border-subtle text-text-muted disabled:opacity-30 disabled:hover:bg-transparent"
             >
               <ChevronLeft className="w-4 h-4" />
             </button>
             <button
               onClick={handleNextVersion}
               disabled={currentVersionIndex <= 0}
-              className="p-1 rounded hover:bg-slate-700 text-slate-400 disabled:opacity-30 disabled:hover:bg-transparent"
+              className="p-1 rounded hover:bg-border-subtle text-text-muted disabled:opacity-30 disabled:hover:bg-transparent"
             >
               <ChevronRight className="w-4 h-4" />
             </button>
@@ -236,10 +239,10 @@ int main() {
         </div>
 
         {/* Code */}
-        <div className="flex-1 bg-[#1e1e1e] relative">
+        <div className="flex-1 bg-surface-overlay relative">
           <Editor
             height="100%"
-            theme="vs-dark"
+            theme={isDark ? 'vs-dark' : 'light'}
             language={activeSolution.lang.toLowerCase().replace('python3', 'python').replace('c++', 'cpp')}
             value={activeVersion.code}
             options={{
@@ -253,25 +256,25 @@ int main() {
         </div>
 
         {/* Comments (Collapsible or Fixed Height) */}
-        <div className="h-64 border-t border-slate-800 bg-[#0F1117] flex flex-col">
-          <div className="p-3 border-b border-slate-800 font-bold text-slate-200 text-sm flex items-center gap-2">
+        <div className="h-64 border-t border-border-default bg-page flex flex-col">
+          <div className="p-3 border-b border-border-default font-bold text-text-secondary text-sm flex items-center gap-2">
             <MessageSquare className="w-4 h-4 text-emerald-500" /> 댓글
           </div>
           <div className="flex-1 overflow-y-auto p-4 space-y-4">
             {comments.map(c => (
               <div key={c.id} className="flex gap-3 text-sm">
-                <div className="font-bold text-slate-300">{c.user}</div>
-                <div className="text-slate-400 flex-1">{c.content}</div>
-                <div className="text-slate-600 text-xs">{c.time}</div>
+                <div className="font-bold text-text-secondary">{c.user}</div>
+                <div className="text-text-muted flex-1">{c.content}</div>
+                <div className="text-text-faint text-xs">{c.time}</div>
               </div>
             ))}
           </div>
-          <div className="p-3 border-t border-slate-800 bg-[#141820]">
+          <div className="p-3 border-t border-border-default bg-surface">
             <div className="relative">
               <input
                 type="text"
                 placeholder="댓글 작성..."
-                className="w-full bg-slate-900 border border-slate-800 rounded-lg py-2 pl-3 pr-10 text-sm text-slate-200 focus:outline-none focus:border-emerald-500"
+                className="w-full bg-input-bg border border-border-default rounded-lg py-2 pl-3 pr-10 text-sm text-text-secondary focus:outline-none focus:border-emerald-500"
               />
               <button className="absolute right-2 top-1/2 -translate-y-1/2 text-emerald-500 hover:text-emerald-400">
                 <MessageSquare className="w-4 h-4" />

--- a/src/features/user/Profile.tsx
+++ b/src/features/user/Profile.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { userState, workspacesState, currentWorkspaceState } from '@/store/atoms';
 import { ArrowLeft } from 'lucide-react';
+import { useIsDark } from '@/App';
 // 잔디(Contribution) 그래프 컴포넌트
 const ContributionGraph = ({ title, activeColorClass = 'emerald' }: { title: string, activeColorClass?: string }) => {
   const weeks = 39;
@@ -33,30 +34,30 @@ const ContributionGraph = ({ title, activeColorClass = 'emerald' }: { title: str
   const getActivityColor = (level: number) => {
     const isEmerald = activeColorClass === 'emerald';
     switch (level) {
-      case 0: return 'bg-[#1e2330]';
+      case 0: return 'bg-surface-subtle';
       case 1: return isEmerald ? 'bg-emerald-900/40' : 'bg-indigo-900/40';
       case 2: return isEmerald ? 'bg-emerald-700/60' : 'bg-indigo-700/60';
       case 3: return isEmerald ? 'bg-emerald-500' : 'bg-indigo-500';
       case 4: return isEmerald ? 'bg-emerald-400' : 'bg-indigo-400';
-      default: return 'bg-[#1e2330]';
+      default: return 'bg-surface-subtle';
     }
   };
 
   return (
-    <Card className="bg-[#151922] border-slate-800 p-6 flex flex-col relative w-full overflow-hidden">
+    <Card className="bg-surface-raised border-border-default p-6 flex flex-col relative w-full overflow-hidden">
       <div className="flex justify-between items-center mb-6">
-        <h2 className="text-lg font-bold text-slate-100">{title}</h2>
+        <h2 className="text-lg font-bold text-text-primary">{title}</h2>
       </div>
 
       <div className="w-full relative">
         {hoverInfo.show && createPortal(
           <div
-            className="fixed z-[9999] px-3 py-2 bg-[#1b202c] text-xs text-white rounded shadow-xl border border-slate-700 pointer-events-none transform -translate-x-1/2 -translate-y-full mt-[-8px]"
+            className="fixed z-[9999] px-3 py-2 bg-surface-inset text-xs text-text-primary rounded shadow-xl border border-border-subtle pointer-events-none transform -translate-x-1/2 -translate-y-full mt-[-8px]"
             style={{ left: hoverInfo.x, top: hoverInfo.y }}
           >
-            <div className="font-bold text-slate-200">{hoverInfo.count} 문제 해결</div>
-            <div className="text-slate-500">{hoverInfo.date}</div>
-            <div className="absolute bottom-[-5px] left-1/2 -translate-x-1/2 w-2 h-2 bg-[#1b202c] border-r border-b border-slate-700 transform rotate-45"></div>
+            <div className="font-bold text-text-secondary">{hoverInfo.count} 문제 해결</div>
+            <div className="text-text-faint">{hoverInfo.date}</div>
+            <div className="absolute bottom-[-5px] left-1/2 -translate-x-1/2 w-2 h-2 bg-surface-inset border-r border-b border-border-subtle transform rotate-45"></div>
           </div>,
           document.body
         )}
@@ -91,6 +92,7 @@ const ContributionGraph = ({ title, activeColorClass = 'emerald' }: { title: str
 
 export const Profile = () => {
   const navigate = useNavigate();
+  const isDark = useIsDark();
   const currentUser = useRecoilValue(userState);
   const workspaces = useRecoilValue(workspacesState);
   const currentWorkspaceId = useRecoilValue(currentWorkspaceState);
@@ -110,7 +112,7 @@ export const Profile = () => {
     { name: 'Correct', value: user.accuracy },
     { name: 'Incorrect', value: 100 - user.accuracy },
   ];
-  const COLORS = ['#34D399', '#1b202c']; // emerald-400 and dark shade
+  const COLORS = ['#34D399', isDark ? '#1b202c' : '#e2e8f0']; // emerald-400 and shade
 
   const tierSolveData = [
     { tier: '브론즈', count: 120, fill: '#b45309' }, // amber-700
@@ -140,64 +142,64 @@ export const Profile = () => {
   const currentStreak = 14;
 
   return (
-    <div className="flex-1 overflow-y-auto bg-[#0a0c10] p-8 pb-12 font-sans text-slate-100">
+    <div className="flex-1 overflow-y-auto bg-page p-8 pb-12 font-sans text-text-primary">
       <div className="max-w-4xl mx-auto space-y-6">
 
         {/* Header Title */}
-        <div className="flex items-center gap-4 mb-10 border-b border-slate-800 pb-4">
+        <div className="flex items-center gap-4 mb-10 border-b border-border-default pb-4">
           <button
             onClick={() => currentWorkspaceId ? navigate(`/ws/${currentWorkspaceId}/dashboard`) : navigate(-1)}
-            className="p-2 -ml-2 text-slate-400 hover:text-white hover:bg-slate-800 rounded-lg transition-colors group"
+            className="p-2 -ml-2 text-text-muted hover:text-text-primary hover:bg-surface-subtle rounded-lg transition-colors group"
           >
             <ArrowLeft className="w-5 h-5 group-hover:-translate-x-1 transition-transform" />
           </button>
-          <h1 className="text-2xl font-extrabold text-slate-100 tracking-tight">내 프로필</h1>
+          <h1 className="text-2xl font-extrabold text-text-primary tracking-tight">내 프로필</h1>
         </div>
 
         {/* ROW 1: 내 정보 상세 & 활동 지표 */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* 1. 내 정보 상세 (좌측 1단) */}
-          <Card className="bg-[#151922] border-slate-800 p-6 relative flex flex-col lg:col-span-1">
+          <Card className="bg-surface-raised border-border-default p-6 relative flex flex-col lg:col-span-1">
             <div className="flex justify-between items-start mb-5">
-              <h2 className="text-base font-bold text-slate-200">내 정보 상세</h2>
+              <h2 className="text-base font-bold text-text-secondary">내 정보 상세</h2>
             </div>
             <div className="grid grid-cols-[80px_1fr] gap-y-3 text-xs items-center">
-              <div className="text-slate-500">닉네임</div>
-              <div className="text-slate-200 font-medium">{user.name}</div>
+              <div className="text-text-faint">닉네임</div>
+              <div className="text-text-secondary font-medium">{user.name}</div>
 
-              <div className="text-slate-500">이메일</div>
-              <div className="text-slate-200 truncate pr-2">{user.email}</div>
+              <div className="text-text-faint">이메일</div>
+              <div className="text-text-secondary truncate pr-2">{user.email}</div>
 
-              <div className="text-slate-500">참여 랩실</div>
-              <div className="text-slate-200 font-medium">{workspaces.length} 곳</div>
+              <div className="text-text-faint">참여 랩실</div>
+              <div className="text-text-secondary font-medium">{workspaces.length} 곳</div>
 
-              <div className="text-slate-500">주력 언어</div>
-              <div className="text-slate-200 font-medium">{bestLanguage}</div>
+              <div className="text-text-faint">주력 언어</div>
+              <div className="text-text-secondary font-medium">{bestLanguage}</div>
 
-              <div className="text-slate-500">해결 문제 수</div>
-              <div className="text-slate-200 font-bold text-emerald-400">{totalSolved} 문제</div>
+              <div className="text-text-faint">해결 문제 수</div>
+              <div className="text-text-secondary font-bold text-emerald-400">{totalSolved} 문제</div>
 
-              <div className="text-slate-500">연속 출석</div>
-              <div className="text-slate-200 font-bold text-blue-400">{currentStreak} 일</div>
+              <div className="text-text-faint">연속 출석</div>
+              <div className="text-text-secondary font-bold text-blue-400">{currentStreak} 일</div>
             </div>
           </Card>
 
           {/* 2. 활동 지표 (우측 2단) */}
-          <Card className="bg-[#151922] border-slate-800 p-6 flex flex-col justify-center lg:col-span-2">
+          <Card className="bg-surface-raised border-border-default p-6 flex flex-col justify-center lg:col-span-2">
             <div className="flex justify-between items-center mb-4">
-              <h2 className="text-base font-bold text-slate-200">활동 지표</h2>
-              <span className="text-[10px] text-slate-500">등급별 풀이 수 & 정답률</span>
+              <h2 className="text-base font-bold text-text-secondary">활동 지표</h2>
+              <span className="text-[10px] text-text-faint">등급별 풀이 수 & 정답률</span>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-center flex-1 h-[200px]">
               {/* Tier Bar Chart */}
-              <div className="w-full h-[180px] bg-[#1b202c] rounded-xl border border-slate-800/80 p-4">
+              <div className="w-full h-[180px] bg-surface-inset rounded-xl border border-border-default/80 p-4">
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={tierSolveData} margin={{ top: 10, right: 10, left: -20, bottom: 0 }} barSize={16}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#334155" vertical={false} />
-                    <XAxis dataKey="tier" axisLine={false} tickLine={false} tick={{ fill: '#94a3b8', fontSize: 10, fontWeight: 'bold' }} dy={10} />
-                    <YAxis axisLine={false} tickLine={false} tick={{ fill: '#64748b', fontSize: 10 }} />
-                    <Tooltip cursor={{ fill: '#334155', opacity: 0.4 }} contentStyle={{ backgroundColor: '#0f1117', borderColor: '#334155', color: '#f1f5f9', borderRadius: '8px', fontSize: '12px' }} />
+                    <CartesianGrid strokeDasharray="3 3" stroke={isDark ? '#334155' : '#e2e8f0'} vertical={false} />
+                    <XAxis dataKey="tier" axisLine={false} tickLine={false} tick={{ fill: isDark ? '#94a3b8' : '#64748b', fontSize: 10, fontWeight: 'bold' }} dy={10} />
+                    <YAxis axisLine={false} tickLine={false} tick={{ fill: isDark ? '#64748b' : '#94a3b8', fontSize: 10 }} />
+                    <Tooltip cursor={{ fill: isDark ? '#334155' : '#e2e8f0', opacity: 0.4 }} contentStyle={{ backgroundColor: isDark ? '#0f1117' : '#ffffff', borderColor: isDark ? '#334155' : '#e2e8f0', color: isDark ? '#f1f5f9' : '#0f172a', borderRadius: '8px', fontSize: '12px' }} />
                     <Bar dataKey="count" radius={[4, 4, 0, 0]} />
                   </BarChart>
                 </ResponsiveContainer>
@@ -207,7 +209,7 @@ export const Profile = () => {
               <div className="flex items-center justify-center relative w-full h-[160px]">
                 <ResponsiveContainer width="100%" height="100%">
                   <PieChart>
-                    <Tooltip contentStyle={{ backgroundColor: '#1b202c', borderColor: '#334155', borderRadius: '8px', color: '#f1f5f9', fontSize: '12px' }} itemStyle={{ color: '#f1f5f9', fontWeight: 'bold' }} cursor={{ fill: 'transparent' }} />
+                    <Tooltip contentStyle={{ backgroundColor: isDark ? '#1b202c' : '#ffffff', borderColor: isDark ? '#334155' : '#e2e8f0', borderRadius: '8px', color: isDark ? '#f1f5f9' : '#0f172a', fontSize: '12px' }} itemStyle={{ color: isDark ? '#f1f5f9' : '#0f172a', fontWeight: 'bold' }} cursor={{ fill: 'transparent' }} />
                     <Pie
                       data={chartData}
                       innerRadius={35}
@@ -224,7 +226,7 @@ export const Profile = () => {
                   </PieChart>
                 </ResponsiveContainer>
                 <div className="absolute flex flex-col items-center justify-center pointer-events-none">
-                  <span className="text-lg font-extrabold text-white">{user.accuracy}%</span>
+                  <span className="text-lg font-extrabold text-text-primary">{user.accuracy}%</span>
                 </div>
               </div>
             </div>
@@ -234,17 +236,17 @@ export const Profile = () => {
         {/* ROW 2: 주력 알고리즘 & 사용 언어 */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {/* 3. 주력 알고리즘 (Radar Chart) */}
-          <Card className="bg-[#151922] border-slate-800 p-6 flex flex-col justify-between shadow-md">
+          <Card className="bg-surface-raised border-border-default p-6 flex flex-col justify-between shadow-md">
             <div className="flex justify-between items-center mb-2">
-              <h2 className="text-base font-bold text-slate-200">주력 알고리즘</h2>
-              <span className="text-[10px] text-slate-500">풀이 유형</span>
+              <h2 className="text-base font-bold text-text-secondary">주력 알고리즘</h2>
+              <span className="text-[10px] text-text-faint">풀이 유형</span>
             </div>
             <div className="w-full h-[320px] flex items-center justify-center mt-4">
               <ResponsiveContainer width="100%" height="100%">
                 <RadarChart cx="50%" cy="50%" outerRadius="90%" data={algorithmData}>
-                  <PolarGrid stroke="#334155" />
-                  <PolarAngleAxis dataKey="subject" tick={{ fill: '#94a3b8', fontSize: 13, fontWeight: 'bold' }} />
-                  <Tooltip contentStyle={{ backgroundColor: '#1b202c', borderColor: '#334155', borderRadius: '8px', color: '#f1f5f9', fontSize: '12px' }} itemStyle={{ color: '#f1f5f9', fontWeight: 'bold' }} cursor={{ fill: 'transparent' }} />
+                  <PolarGrid stroke={isDark ? '#334155' : '#e2e8f0'} />
+                  <PolarAngleAxis dataKey="subject" tick={{ fill: isDark ? '#94a3b8' : '#64748b', fontSize: 13, fontWeight: 'bold' }} />
+                  <Tooltip contentStyle={{ backgroundColor: isDark ? '#1b202c' : '#ffffff', borderColor: isDark ? '#334155' : '#e2e8f0', borderRadius: '8px', color: isDark ? '#f1f5f9' : '#0f172a', fontSize: '12px' }} itemStyle={{ color: isDark ? '#f1f5f9' : '#0f172a', fontWeight: 'bold' }} cursor={{ fill: 'transparent' }} />
                   <Radar name="User" dataKey="A" stroke="#8b5cf6" fill="#8b5cf6" fillOpacity={0.5} />
                 </RadarChart>
               </ResponsiveContainer>
@@ -252,23 +254,23 @@ export const Profile = () => {
           </Card>
 
           {/* 4. 주력 언어 (Pie Chart) */}
-          <Card className="bg-[#151922] border-slate-800 p-6 flex flex-col justify-between shadow-md">
+          <Card className="bg-surface-raised border-border-default p-6 flex flex-col justify-between shadow-md">
             <div className="flex justify-between items-center mb-2">
-              <h2 className="text-base font-bold text-slate-200">주력 언어</h2>
-              <span className="text-[10px] text-slate-500">제출 언어 비중</span>
+              <h2 className="text-base font-bold text-text-secondary">주력 언어</h2>
+              <span className="text-[10px] text-text-faint">제출 언어 비중</span>
             </div>
 
             <div className="w-full flex-1 min-h-[250px] flex items-center justify-center mt-2 relative">
               <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
-                  <Tooltip contentStyle={{ backgroundColor: '#1b202c', borderColor: '#334155', borderRadius: '8px', color: '#f1f5f9', fontSize: '12px' }} itemStyle={{ color: '#f1f5f9', fontWeight: 'bold' }} cursor={{ fill: 'transparent' }} />
+                  <Tooltip contentStyle={{ backgroundColor: isDark ? '#1b202c' : '#ffffff', borderColor: isDark ? '#334155' : '#e2e8f0', borderRadius: '8px', color: isDark ? '#f1f5f9' : '#0f172a', fontSize: '12px' }} itemStyle={{ color: isDark ? '#f1f5f9' : '#0f172a', fontWeight: 'bold' }} cursor={{ fill: 'transparent' }} />
                   <Pie
                     data={languageData}
                     cx="50%"
                     cy="50%"
                     outerRadius="90%"
                     dataKey="value"
-                    stroke="#151922"
+                    stroke={isDark ? '#151922' : '#ffffff'}
                     strokeWidth={2}
                   >
                     {languageData.map((entry, index) => (
@@ -283,11 +285,11 @@ export const Profile = () => {
               {/* 언어별 범례(Legend) - 3열 Grid 전체 나열 */}
               <div className="grid grid-cols-3 w-full gap-2">
                 {languageData.map((lang, idx) => (
-                  <div key={idx} className="flex items-center gap-1.5 bg-[#1b202c] px-2 py-1.5 rounded-lg border border-slate-800/50 justify-center min-w-0 overflow-hidden hover:bg-slate-800 hover:border-slate-600 transition-colors cursor-default">
+                  <div key={idx} className="flex items-center gap-1.5 bg-surface-inset px-2 py-1.5 rounded-lg border border-border-default/50 justify-center min-w-0 overflow-hidden hover:bg-surface-subtle hover:border-border-subtle transition-colors cursor-default">
                     <div className="w-2.5 h-2.5 rounded-full shadow-sm flex-shrink-0" style={{ backgroundColor: lang.color }}></div>
                     <div className="flex gap-1.5 items-center truncate">
-                      <span className="text-xs font-bold text-slate-200 truncate">{lang.name}</span>
-                      <span className="text-[10px] text-slate-400 font-medium whitespace-nowrap">{lang.value}%</span>
+                      <span className="text-xs font-bold text-text-secondary truncate">{lang.name}</span>
+                      <span className="text-[10px] text-text-muted font-medium whitespace-nowrap">{lang.value}%</span>
                     </div>
                   </div>
                 ))}
@@ -300,24 +302,24 @@ export const Profile = () => {
         <ContributionGraph title="Daily Streak" activeColorClass="emerald" />
 
         {/* 5. 힌트보기 설정 */}
-        <Card className="bg-[#151922] border-slate-800 p-8 flex justify-between items-center">
+        <Card className="bg-surface-raised border-border-default p-8 flex justify-between items-center">
           <div>
-            <h2 className="text-lg font-bold text-slate-200">힌트보기 설정</h2>
+            <h2 className="text-lg font-bold text-text-secondary">힌트보기 설정</h2>
           </div>
           <div className="flex items-center gap-6">
-            <span className="text-xs text-slate-500 mr-2">문제 풀이 시 힌트 표시 여부</span>
+            <span className="text-xs text-text-faint mr-2">문제 풀이 시 힌트 표시 여부</span>
             <label className="flex items-center gap-2 cursor-pointer">
-              <div className={`w-4 h-4 rounded-full border-2 flex items-center justify-center ${hintSettings === 'on' ? 'border-indigo-500' : 'border-slate-600'}`}>
+              <div className={`w-4 h-4 rounded-full border-2 flex items-center justify-center ${hintSettings === 'on' ? 'border-indigo-500' : 'border-border-subtle'}`}>
                 {hintSettings === 'on' && <div className="w-2 h-2 rounded-full bg-indigo-500"></div>}
               </div>
-              <span className={`text-sm font-bold ${hintSettings === 'on' ? 'text-slate-200' : 'text-slate-500'}`}>On</span>
+              <span className={`text-sm font-bold ${hintSettings === 'on' ? 'text-text-secondary' : 'text-text-faint'}`}>On</span>
               <input type="radio" className="hidden" checked={hintSettings === 'on'} onChange={() => setHintSettings('on')} />
             </label>
             <label className="flex items-center gap-2 cursor-pointer">
-              <div className={`w-4 h-4 rounded-full border-2 flex items-center justify-center ${hintSettings === 'off' ? 'border-indigo-500' : 'border-slate-600'}`}>
+              <div className={`w-4 h-4 rounded-full border-2 flex items-center justify-center ${hintSettings === 'off' ? 'border-indigo-500' : 'border-border-subtle'}`}>
                 {hintSettings === 'off' && <div className="w-2 h-2 rounded-full bg-indigo-500"></div>}
               </div>
-              <span className={`text-sm font-bold ${hintSettings === 'off' ? 'text-slate-200' : 'text-slate-500'}`}>Off</span>
+              <span className={`text-sm font-bold ${hintSettings === 'off' ? 'text-text-secondary' : 'text-text-faint'}`}>Off</span>
               <input type="radio" className="hidden" checked={hintSettings === 'off'} onChange={() => setHintSettings('off')} />
             </label>
           </div>

--- a/src/features/user/Settings.tsx
+++ b/src/features/user/Settings.tsx
@@ -76,37 +76,37 @@ export const Settings = () => {
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm p-8" onClick={() => navigate(-1)}>
-      <div className="w-full max-w-5xl h-[85vh] bg-white dark:bg-[#1e1e1e] rounded-xl shadow-2xl flex overflow-hidden border border-slate-700/50" onClick={e => e.stopPropagation()}>
+      <div className="w-full max-w-5xl h-[85vh] bg-surface-overlay rounded-xl shadow-2xl flex overflow-hidden border border-border-subtle/50" onClick={e => e.stopPropagation()}>
 
         {/* Sidebar */}
-        <div className="w-64 bg-[#f7f7f5] dark:bg-[#252525] border-r border-slate-200 dark:border-slate-800 flex flex-col">
+        <div className="w-64 bg-[#f7f7f5] dark:bg-[#252525] border-r border-border-subtle flex flex-col">
           {/* Header */}
-          <div className="p-4 border-b border-slate-200 dark:border-slate-800 flex items-center justify-between">
+          <div className="p-4 border-b border-border-default flex items-center justify-between">
             <div className="flex items-center gap-2 overflow-hidden">
-              <div className="w-6 h-6 rounded-full bg-slate-300 dark:bg-slate-700 flex items-center justify-center text-xs overflow-hidden">
+              <div className="w-6 h-6 rounded-full bg-border-subtle flex items-center justify-center text-xs overflow-hidden">
                 {user.profileImageUrl ? (
                   <img src={user.profileImageUrl} alt="" className="w-full h-full object-cover" />
                 ) : (
-                  <span className="text-[10px] font-bold text-slate-500 dark:text-slate-400">
+                  <span className="text-[10px] font-bold text-text-muted">
                     {(user.name || 'U').charAt(0).toUpperCase()}
                   </span>
                 )}
               </div>
-              <span className="font-medium text-sm text-slate-700 dark:text-slate-200 truncate">{user.name || 'User'}</span>
+              <span className="font-medium text-sm text-text-secondary truncate">{user.name || 'User'}</span>
             </div>
           </div>
 
-          <div className="flex-1 overflow-y-auto py-2">
+          <div className="flex-1 overflow-y-auto py-3">
             {/* Account Section */}
-            <div className="px-3 mb-4">
-              <div className="text-[11px] font-bold text-slate-500 mb-1 px-2">계정</div>
+            <div className="px-3">
+              <div className="text-[11px] font-bold text-text-faint mb-1 px-2">계정</div>
               {accountTabs.map(tab => (
                 <button
                   key={tab.id}
                   onClick={() => setActiveTab(tab.id)}
                   className={`w-full flex items-center gap-2.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${activeTab === tab.id
-                    ? 'bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100'
-                    : 'text-slate-500 dark:text-slate-400 hover:bg-slate-200/50 dark:hover:bg-slate-700/50 hover:text-slate-900 dark:hover:text-slate-200'
+                    ? 'bg-surface-subtle dark:bg-border-subtle text-text-primary'
+                    : 'text-text-faint hover:bg-hover-bg hover:text-text-secondary'
                     }`}
                 >
                   <tab.icon className="w-4 h-4" />
@@ -117,15 +117,15 @@ export const Settings = () => {
 
             {/* Workspace Section - only show when workspaces exist */}
             {workspaces.length > 0 && (
-              <div className="px-3">
-                <div className="text-[11px] font-bold text-slate-500 mb-1 px-2">워크스페이스</div>
+              <div className="px-3 mt-3 pt-3">
+                <div className="text-[11px] font-bold text-text-faint mb-1 px-2">워크스페이스</div>
                 {workspaceTabs.map(tab => (
                   <button
                     key={tab.id}
                     onClick={() => setActiveTab(tab.id)}
                     className={`w-full flex items-center gap-2.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${activeTab === tab.id
-                      ? 'bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100'
-                      : 'text-slate-500 dark:text-slate-400 hover:bg-slate-200/50 dark:hover:bg-slate-700/50 hover:text-slate-900 dark:hover:text-slate-200'
+                      ? 'bg-surface-subtle dark:bg-border-subtle text-text-primary'
+                      : 'text-text-faint hover:bg-hover-bg hover:text-text-secondary'
                       }`}
                   >
                     <tab.icon className="w-4 h-4" />
@@ -138,10 +138,10 @@ export const Settings = () => {
         </div>
 
         {/* Content Area */}
-        <div className="flex-1 flex flex-col bg-white dark:bg-[#1e1e1e] relative">
+        <div className="flex-1 flex flex-col bg-surface-overlay relative">
           <button
             onClick={() => navigate(-1)}
-            className="absolute top-4 right-4 p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors"
+            className="absolute top-4 right-4 p-2 rounded-full hover:bg-hover-bg text-text-faint transition-colors"
           >
             <X className="w-5 h-5" />
           </button>

--- a/src/features/user/settings/ConnectionsTab.tsx
+++ b/src/features/user/settings/ConnectionsTab.tsx
@@ -4,44 +4,44 @@ import { Github, Trello, Slack } from 'lucide-react';
 export const ConnectionsTab = () => {
   return (
     <div className="space-y-8 animate-in fade-in duration-300">
-      <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100 pb-4 border-b border-slate-200 dark:border-slate-800">연결된 계정</h2>
+      <h2 className="text-xl font-bold text-text-primary pb-4 border-b border-border-default">연결된 계정</h2>
       <div className="space-y-4">
-        <p className="text-sm text-slate-500">다른 서비스와 연결하여 UJAX의 기능을 확장하세요.</p>
+        <p className="text-sm text-text-faint">다른 서비스와 연결하여 UJAX의 기능을 확장하세요.</p>
 
-        <div className="flex items-center justify-between p-4 bg-slate-100 dark:bg-slate-800/50 rounded-lg border border-slate-200 dark:border-slate-700">
+        <div className="flex items-center justify-between p-4 bg-surface-subtle/50 rounded-lg border border-border-subtle">
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 bg-white rounded flex items-center justify-center text-black">
               <Github className="w-6 h-6" />
             </div>
             <div>
-              <div className="text-sm font-bold text-slate-900 dark:text-slate-100">GitHub</div>
-              <div className="text-xs text-slate-500">PR 및 이슈 상태 동기화</div>
+              <div className="text-sm font-bold text-text-primary">GitHub</div>
+              <div className="text-xs text-text-faint">PR 및 이슈 상태 동기화</div>
             </div>
           </div>
           <Button variant="secondary" size="sm">연결하기</Button>
         </div>
 
-        <div className="flex items-center justify-between p-4 bg-slate-100 dark:bg-slate-800/50 rounded-lg border border-slate-200 dark:border-slate-700">
+        <div className="flex items-center justify-between p-4 bg-surface-subtle/50 rounded-lg border border-border-subtle">
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 bg-[#0079BF] rounded flex items-center justify-center text-white">
               <Trello className="w-6 h-6" />
             </div>
             <div>
-              <div className="text-sm font-bold text-slate-900 dark:text-slate-100">Trello</div>
-              <div className="text-xs text-slate-500">보드 가져오기 및 동기화</div>
+              <div className="text-sm font-bold text-text-primary">Trello</div>
+              <div className="text-xs text-text-faint">보드 가져오기 및 동기화</div>
             </div>
           </div>
           <Button variant="secondary" size="sm">연결하기</Button>
         </div>
 
-        <div className="flex items-center justify-between p-4 bg-slate-100 dark:bg-slate-800/50 rounded-lg border border-slate-200 dark:border-slate-700">
+        <div className="flex items-center justify-between p-4 bg-surface-subtle/50 rounded-lg border border-border-subtle">
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 bg-[#4A154B] rounded flex items-center justify-center text-white">
               <Slack className="w-6 h-6" />
             </div>
             <div>
-              <div className="text-sm font-bold text-slate-900 dark:text-slate-100">Slack</div>
-              <div className="text-xs text-slate-500">알림 전송 및 미리보기</div>
+              <div className="text-sm font-bold text-text-primary">Slack</div>
+              <div className="text-xs text-text-faint">알림 전송 및 미리보기</div>
             </div>
           </div>
           <Button variant="secondary" size="sm">연결하기</Button>

--- a/src/features/user/settings/GeneralTab.tsx
+++ b/src/features/user/settings/GeneralTab.tsx
@@ -1,30 +1,39 @@
+import { useRecoilState } from 'recoil';
+import { themeState, ThemeMode } from '@/store/atoms';
+
 export const GeneralTab = () => {
+  const [theme, setTheme] = useRecoilState(themeState);
+
   return (
     <div className="space-y-8 animate-in fade-in duration-300">
-      <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100 pb-4 border-b border-slate-200 dark:border-slate-800">기본 설정</h2>
+      <h2 className="text-xl font-bold text-text-primary pb-4 border-b border-border-default">기본 설정</h2>
 
       <div className="space-y-6">
         <div className="flex items-center justify-between py-2">
           <div>
-            <div className="text-sm font-medium text-slate-900 dark:text-slate-200">테마</div>
-            <div className="text-xs text-slate-500">내 기기에서 UJAX의 모습을 마음껏 바꿔보세요.</div>
+            <div className="text-sm font-medium text-text-secondary">테마</div>
+            <div className="text-xs text-text-faint">내 기기에서 UJAX의 모습을 마음껏 바꿔보세요.</div>
           </div>
-          <select className="bg-transparent border border-slate-300 dark:border-slate-700 rounded px-2 py-1 text-sm text-slate-700 dark:text-slate-300">
-            <option>시스템 설정 사용</option>
-            <option>라이트 모드</option>
-            <option>다크 모드</option>
+          <select
+            value={theme}
+            onChange={(e) => setTheme(e.target.value as ThemeMode)}
+            className="bg-transparent border border-border-subtle rounded px-2 py-1 text-sm text-text-secondary"
+          >
+            <option value="system">시스템 설정 사용</option>
+            <option value="light">라이트 모드</option>
+            <option value="dark">다크 모드</option>
           </select>
         </div>
 
-        <div className="pt-6 border-t border-slate-200 dark:border-slate-800">
-          <h3 className="text-sm font-bold text-slate-700 dark:text-slate-300 mb-4">언어 및 시간</h3>
+        <div className="pt-6 border-t border-border-default">
+          <h3 className="text-sm font-bold text-text-secondary mb-4">언어 및 시간</h3>
 
           <div className="flex items-center justify-between py-2">
             <div>
-              <div className="text-sm font-medium text-slate-900 dark:text-slate-200">언어</div>
-              <div className="text-xs text-slate-500">UJAX에서 사용하는 언어를 변경하세요.</div>
+              <div className="text-sm font-medium text-text-secondary">언어</div>
+              <div className="text-xs text-text-faint">UJAX에서 사용하는 언어를 변경하세요.</div>
             </div>
-            <select className="bg-transparent border border-slate-300 dark:border-slate-700 rounded px-2 py-1 text-sm text-slate-700 dark:text-slate-300">
+            <select className="bg-transparent border border-border-subtle rounded px-2 py-1 text-sm text-text-secondary">
               <option>한국어</option>
               <option>English</option>
             </select>
@@ -32,12 +41,12 @@ export const GeneralTab = () => {
 
           <div className="flex items-center justify-between py-2 mt-4">
             <div>
-              <div className="text-sm font-medium text-slate-900 dark:text-slate-200">텍스트 방향 제어 항상 표시</div>
-              <div className="text-xs text-slate-500 max-w-md">언어가 왼쪽에서 오른쪽으로 표시되는 경우에도 편집기 메뉴에 텍스트 방향(LTR/RTL)을 변경하는 옵션을 표시합니다.</div>
+              <div className="text-sm font-medium text-text-secondary">텍스트 방향 제어 항상 표시</div>
+              <div className="text-xs text-text-faint max-w-md">언어가 왼쪽에서 오른쪽으로 표시되는 경우에도 편집기 메뉴에 텍스트 방향(LTR/RTL)을 변경하는 옵션을 표시합니다.</div>
             </div>
             <div className="relative inline-block w-10 h-5 transition duration-200 ease-in-out">
               <input type="checkbox" className="peer absolute opacity-0 w-0 h-0" />
-              <label className="block w-10 h-5 bg-slate-300 dark:bg-slate-700 rounded-full cursor-pointer peer-checked:bg-emerald-500 transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:left-[22px]"></label>
+              <label className="block w-10 h-5 bg-border-subtle rounded-full cursor-pointer peer-checked:bg-emerald-500 transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:left-[22px]"></label>
             </div>
           </div>
         </div>

--- a/src/features/user/settings/NotificationsTab.tsx
+++ b/src/features/user/settings/NotificationsTab.tsx
@@ -1,26 +1,26 @@
 export const NotificationsTab = () => {
   return (
     <div className="space-y-8 animate-in fade-in duration-300">
-      <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100 pb-4 border-b border-slate-200 dark:border-slate-800">알림 설정</h2>
+      <h2 className="text-xl font-bold text-text-primary pb-4 border-b border-border-default">알림 설정</h2>
       <div className="space-y-6">
         <div className="flex items-center justify-between py-2">
           <div>
-            <div className="text-sm font-medium text-slate-900 dark:text-slate-200">이메일 알림</div>
-            <div className="text-xs text-slate-500">새로운 멘션, 페이지 초대 등에 대한 알림을 받습니다.</div>
+            <div className="text-sm font-medium text-text-secondary">이메일 알림</div>
+            <div className="text-xs text-text-faint">새로운 멘션, 페이지 초대 등에 대한 알림을 받습니다.</div>
           </div>
           <div className="relative inline-block w-10 h-5">
             <input type="checkbox" defaultChecked className="peer absolute opacity-0 w-0 h-0" />
-            <label className="block w-10 h-5 bg-slate-300 dark:bg-slate-700 rounded-full cursor-pointer peer-checked:bg-emerald-500 transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:left-[22px]"></label>
+            <label className="block w-10 h-5 bg-border-subtle rounded-full cursor-pointer peer-checked:bg-emerald-500 transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:left-[22px]"></label>
           </div>
         </div>
         <div className="flex items-center justify-between py-2">
           <div>
-            <div className="text-sm font-medium text-slate-900 dark:text-slate-200">모바일 푸시 알림</div>
-            <div className="text-xs text-slate-500">모바일 기기로 중요 알림을 전송합니다.</div>
+            <div className="text-sm font-medium text-text-secondary">모바일 푸시 알림</div>
+            <div className="text-xs text-text-faint">모바일 기기로 중요 알림을 전송합니다.</div>
           </div>
           <div className="relative inline-block w-10 h-5">
             <input type="checkbox" className="peer absolute opacity-0 w-0 h-0" />
-            <label className="block w-10 h-5 bg-slate-300 dark:bg-slate-700 rounded-full cursor-pointer peer-checked:bg-emerald-500 transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:left-[22px]"></label>
+            <label className="block w-10 h-5 bg-border-subtle rounded-full cursor-pointer peer-checked:bg-emerald-500 transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:left-[22px]"></label>
           </div>
         </div>
       </div>

--- a/src/features/user/settings/ProfileTab.tsx
+++ b/src/features/user/settings/ProfileTab.tsx
@@ -209,14 +209,14 @@ export const ProfileTab = () => {
 
   return (
     <div className="space-y-8 animate-in fade-in duration-300">
-      <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100 pb-4 border-b border-slate-200 dark:border-slate-800">내 프로필</h2>
+      <h2 className="text-xl font-bold text-text-primary pb-4 border-b border-border-default">내 프로필</h2>
 
       <div className="flex items-start gap-6">
-        <div className="w-24 h-24 rounded-full bg-slate-200 dark:bg-slate-800 overflow-hidden flex-shrink-0 flex items-center justify-center">
+        <div className="w-24 h-24 rounded-full bg-surface-subtle overflow-hidden flex-shrink-0 flex items-center justify-center">
           {avatarSrc ? (
             <img src={avatarSrc} alt="Profile" className="w-full h-full object-cover" />
           ) : (
-            <span className="text-3xl font-bold text-slate-500 dark:text-slate-400">{nameInitial}</span>
+            <span className="text-3xl font-bold text-text-muted">{nameInitial}</span>
           )}
         </div>
         <div className="space-y-4 flex-1">
@@ -231,28 +231,28 @@ export const ProfileTab = () => {
             <Button variant="secondary" size="sm" onClick={() => fileInputRef.current?.click()}>사진 변경</Button>
             <Button variant="ghost" size="sm" className="text-red-500 hover:text-red-600" onClick={handleRemovePhoto}>제거</Button>
           </div>
-          <p className="text-xs text-slate-500">최대 5MB의 JPG, PNG 또는 WEBP 형식을 지원합니다.</p>
+          <p className="text-xs text-text-faint">최대 5MB의 JPG, PNG 또는 WEBP 형식을 지원합니다.</p>
         </div>
       </div>
 
       <div className="space-y-4 max-w-md">
-        <h3 className="text-sm font-bold text-slate-700 dark:text-slate-300">기본 정보</h3>
+        <h3 className="text-sm font-bold text-text-secondary">기본 정보</h3>
         <div>
-          <label className="block text-xs font-bold text-slate-500 mb-1">이메일</label>
-          <input type="email" value={email} disabled className="w-full bg-slate-100 dark:bg-slate-800 border border-slate-300 dark:border-slate-700 rounded px-3 py-1.5 text-sm text-slate-500 cursor-not-allowed" />
+          <label className="block text-xs font-bold text-text-faint mb-1">이메일</label>
+          <input type="email" value={email} disabled className="w-full bg-surface-subtle border border-border-subtle rounded px-3 py-1.5 text-sm text-text-faint cursor-not-allowed" />
         </div>
         <div>
-          <label className="block text-xs font-bold text-slate-500 mb-1">이름</label>
-          <input type="text" value={name} onChange={e => setName(e.target.value)} className="w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded px-3 py-1.5 text-sm text-slate-900 dark:text-slate-200 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
+          <label className="block text-xs font-bold text-text-faint mb-1">이름</label>
+          <input type="text" value={name} onChange={e => setName(e.target.value)} className="w-full bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm text-text-secondary focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
         </div>
       </div>
 
       <div className="pt-2 space-y-4 max-w-md">
-        <h3 className="text-sm font-bold text-slate-700 dark:text-slate-300">연동 계정</h3>
+        <h3 className="text-sm font-bold text-text-secondary">연동 계정</h3>
         <div>
-          <label className="block text-xs font-bold text-slate-500 mb-1">백준 아이디</label>
-          <input type="text" value={baekjoonId} onChange={e => setBaekjoonId(e.target.value)} placeholder="백준 아이디를 입력하세요" className="w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded px-3 py-1.5 text-sm text-slate-900 dark:text-slate-200 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
-          <p className="text-[11px] text-slate-400 mt-1">solved.ac 티어 연동에 사용됩니다.</p>
+          <label className="block text-xs font-bold text-text-faint mb-1">백준 아이디</label>
+          <input type="text" value={baekjoonId} onChange={e => setBaekjoonId(e.target.value)} placeholder="백준 아이디를 입력하세요" className="w-full bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm text-text-secondary focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
+          <p className="text-[11px] text-text-faint mt-1">solved.ac 티어 연동에 사용됩니다.</p>
         </div>
         <div className="space-y-2 pt-2">
           <Button
@@ -268,16 +268,16 @@ export const ProfileTab = () => {
         </div>
       </div>
 
-      <div className="pt-6 border-t border-red-200 dark:border-red-500/20">
+      <div className="pt-6 border-t border-red-500/20">
         <h3 className="text-sm font-bold text-red-500 mb-4">위험 구역</h3>
-        <div className="rounded-lg border border-red-200 dark:border-red-500/20 bg-red-50 dark:bg-red-500/5 p-4 flex items-center justify-between">
+        <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-4 flex items-center justify-between">
           <div>
-            <div className="text-sm font-medium text-slate-900 dark:text-slate-200">계정 삭제</div>
-            <div className="text-xs text-slate-500 mt-0.5">계정을 삭제하면 모든 데이터가 영구적으로 제거됩니다.</div>
+            <div className="text-sm font-medium text-text-secondary">계정 삭제</div>
+            <div className="text-xs text-text-faint mt-0.5">계정을 삭제하면 모든 데이터가 영구적으로 제거됩니다.</div>
           </div>
           <Button
             variant="ghost"
-            className="text-red-500 hover:text-white hover:bg-red-600 border border-red-300 dark:border-red-500/30 ml-4 flex-shrink-0"
+            className="text-red-500 hover:text-white hover:bg-red-600 border border-red-500/30 ml-4 flex-shrink-0"
             onClick={() => { setShowDeleteModal(true); setDeleteConfirmEmail(''); setDeleteError(''); }}
           >
             계정 삭제
@@ -287,34 +287,34 @@ export const ProfileTab = () => {
 
       {showDeleteModal && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={() => !deleting && setShowDeleteModal(false)}>
-          <div className="bg-white dark:bg-[#1e1e1e] rounded-xl shadow-2xl border border-slate-700/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
+          <div className="bg-surface-overlay rounded-xl shadow-2xl border border-border-subtle/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-red-100 dark:bg-red-500/10 flex items-center justify-center">
+              <div className="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center">
                 <AlertTriangle className="w-5 h-5 text-red-500" />
               </div>
-              <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">계정 삭제</h3>
+              <h3 className="text-lg font-bold text-text-primary">계정 삭제</h3>
             </div>
 
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-text-faint">
               이 작업은 되돌릴 수 없습니다. 모든 데이터가 영구 삭제됩니다.
             </p>
 
             <div>
-              <label className="block text-xs font-medium text-slate-500 mb-1.5">
-                확인을 위해 이메일(<span className="font-bold text-slate-700 dark:text-slate-300">{email}</span>)을 입력하세요
+              <label className="block text-xs font-medium text-text-faint mb-1.5">
+                확인을 위해 이메일(<span className="font-bold text-text-secondary">{email}</span>)을 입력하세요
               </label>
               <input
                 type="email"
                 value={deleteConfirmEmail}
                 onChange={e => setDeleteConfirmEmail(e.target.value)}
                 placeholder={email}
-                className="w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded px-3 py-1.5 text-sm text-slate-900 dark:text-slate-200 focus:border-red-500 focus:ring-1 focus:ring-red-500 outline-none"
+                className="w-full bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm text-text-secondary focus:border-red-500 focus:ring-1 focus:ring-red-500 outline-none"
                 autoFocus
               />
             </div>
 
             {deleteError && (
-              <p className="text-xs text-red-500 bg-red-50 dark:bg-red-500/10 rounded px-3 py-2">{deleteError}</p>
+              <p className="text-xs text-red-500 bg-red-500/10 rounded px-3 py-2">{deleteError}</p>
             )}
 
             <div className="flex justify-end gap-2 pt-2">

--- a/src/features/user/settings/WsGeneralTab.tsx
+++ b/src/features/user/settings/WsGeneralTab.tsx
@@ -150,26 +150,26 @@ export const WsGeneralTab = () => {
 
   return (
     <div className="space-y-8 animate-in fade-in duration-300">
-      <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100 pb-4 border-b border-slate-200 dark:border-slate-800">워크스페이스 일반 설정</h2>
+      <h2 className="text-xl font-bold text-text-primary pb-4 border-b border-border-default">워크스페이스 일반 설정</h2>
 
       <div className="space-y-4 max-w-md">
-        <h3 className="text-sm font-bold text-slate-700 dark:text-slate-300">워크스페이스 정보</h3>
+        <h3 className="text-sm font-bold text-text-secondary">워크스페이스 정보</h3>
         <div>
-          <label className="block text-xs font-bold text-slate-500 mb-1">이름</label>
-          <input type="text" value={wsName} onChange={e => setWsName(e.target.value)} className="w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded px-3 py-1.5 text-sm text-slate-900 dark:text-slate-200 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
+          <label className="block text-xs font-bold text-text-faint mb-1">이름</label>
+          <input type="text" value={wsName} onChange={e => setWsName(e.target.value)} className="w-full bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm text-text-secondary focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
         </div>
         <div>
-          <label className="block text-xs font-bold text-slate-500 mb-1">설명</label>
-          <input type="text" value={wsDescription} onChange={e => setWsDescription(e.target.value)} placeholder="워크스페이스 설명을 입력하세요" className="w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded px-3 py-1.5 text-sm text-slate-900 dark:text-slate-200 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
+          <label className="block text-xs font-bold text-text-faint mb-1">설명</label>
+          <input type="text" value={wsDescription} onChange={e => setWsDescription(e.target.value)} placeholder="워크스페이스 설명을 입력하세요" className="w-full bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm text-text-secondary focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
         </div>
       </div>
 
       <div className="pt-2 space-y-4 max-w-md">
-        <h3 className="text-sm font-bold text-slate-700 dark:text-slate-300">연동</h3>
+        <h3 className="text-sm font-bold text-text-secondary">연동</h3>
         <div>
-          <label className="block text-xs font-bold text-slate-500 mb-1">Mattermost Webhook URL</label>
-          <input type="text" value={wsMmWebhookUrl} onChange={e => setWsMmWebhookUrl(e.target.value)} placeholder="https://mattermost.example.com/hooks/..." className="w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded px-3 py-1.5 text-sm text-slate-900 dark:text-slate-200 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
-          <p className="text-[11px] text-slate-400 mt-1">알림을 받을 Mattermost 채널의 Webhook URL을 입력하세요.</p>
+          <label className="block text-xs font-bold text-text-faint mb-1">Mattermost Webhook URL</label>
+          <input type="text" value={wsMmWebhookUrl} onChange={e => setWsMmWebhookUrl(e.target.value)} placeholder="https://mattermost.example.com/hooks/..." className="w-full bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm text-text-secondary focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
+          <p className="text-[11px] text-text-faint mt-1">알림을 받을 Mattermost 채널의 Webhook URL을 입력하세요.</p>
         </div>
         <div className="space-y-2 pt-2">
           <Button
@@ -185,12 +185,12 @@ export const WsGeneralTab = () => {
         </div>
       </div>
 
-      <div className="pt-6 border-t border-slate-200 dark:border-slate-800 space-y-4 max-w-md">
-        <h3 className="text-sm font-bold text-slate-700 dark:text-slate-300">내 설정</h3>
+      <div className="pt-6 border-t border-border-default space-y-4 max-w-md">
+        <h3 className="text-sm font-bold text-text-secondary">내 설정</h3>
         <div>
-          <label className="block text-xs font-bold text-slate-500 mb-1">닉네임</label>
-          <input type="text" value={wsNickname} onChange={e => setWsNickname(e.target.value)} placeholder="이 워크스페이스에서 사용할 닉네임" className="w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded px-3 py-1.5 text-sm text-slate-900 dark:text-slate-200 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
-          <p className="text-[11px] text-slate-400 mt-1">이 워크스페이스에서 다른 멤버에게 보이는 이름입니다.</p>
+          <label className="block text-xs font-bold text-text-faint mb-1">닉네임</label>
+          <input type="text" value={wsNickname} onChange={e => setWsNickname(e.target.value)} placeholder="이 워크스페이스에서 사용할 닉네임" className="w-full bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm text-text-secondary focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
+          <p className="text-[11px] text-text-faint mt-1">이 워크스페이스에서 다른 멤버에게 보이는 이름입니다.</p>
         </div>
         <div className="space-y-2 pt-2">
           <Button
@@ -206,30 +206,30 @@ export const WsGeneralTab = () => {
         </div>
       </div>
 
-      <div className="pt-6 border-t border-red-200 dark:border-red-500/20">
+      <div className="pt-6 border-t border-red-500/20">
         <h3 className="text-sm font-bold text-red-500 mb-4">위험 구역</h3>
         <div className="space-y-3">
-          <div className="rounded-lg border border-red-200 dark:border-red-500/20 bg-red-50 dark:bg-red-500/5 p-4 flex items-center justify-between">
+          <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-4 flex items-center justify-between">
             <div>
-              <div className="text-sm font-medium text-slate-900 dark:text-slate-200">워크스페이스 나가기</div>
-              <div className="text-xs text-slate-500 mt-0.5">이 워크스페이스에서 나갑니다. 다시 참여하려면 초대가 필요합니다.</div>
+              <div className="text-sm font-medium text-text-secondary">워크스페이스 나가기</div>
+              <div className="text-xs text-text-faint mt-0.5">이 워크스페이스에서 나갑니다. 다시 참여하려면 초대가 필요합니다.</div>
             </div>
             <Button
               variant="ghost"
-              className="text-red-500 hover:text-white hover:bg-red-600 border border-red-300 dark:border-red-500/30 ml-4 flex-shrink-0"
+              className="text-red-500 hover:text-white hover:bg-red-600 border border-red-500/30 ml-4 flex-shrink-0"
               onClick={() => { setShowWsLeaveModal(true); setWsLeaveError(''); }}
             >
               <LogOut className="w-4 h-4 mr-1.5" />나가기
             </Button>
           </div>
-          <div className="rounded-lg border border-red-200 dark:border-red-500/20 bg-red-50 dark:bg-red-500/5 p-4 flex items-center justify-between">
+          <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-4 flex items-center justify-between">
             <div>
-              <div className="text-sm font-medium text-slate-900 dark:text-slate-200">워크스페이스 삭제</div>
-              <div className="text-xs text-slate-500 mt-0.5">워크스페이스와 모든 데이터가 영구적으로 삭제됩니다.</div>
+              <div className="text-sm font-medium text-text-secondary">워크스페이스 삭제</div>
+              <div className="text-xs text-text-faint mt-0.5">워크스페이스와 모든 데이터가 영구적으로 삭제됩니다.</div>
             </div>
             <Button
               variant="ghost"
-              className="text-red-500 hover:text-white hover:bg-red-600 border border-red-300 dark:border-red-500/30 ml-4 flex-shrink-0"
+              className="text-red-500 hover:text-white hover:bg-red-600 border border-red-500/30 ml-4 flex-shrink-0"
               onClick={() => { setShowWsDeleteModal(true); setWsDeleteConfirmName(''); setWsDeleteError(''); }}
             >
               삭제
@@ -241,20 +241,20 @@ export const WsGeneralTab = () => {
       {/* 워크스페이스 나가기 모달 */}
       {showWsLeaveModal && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={() => !wsLeaving && setShowWsLeaveModal(false)}>
-          <div className="bg-white dark:bg-[#1e1e1e] rounded-xl shadow-2xl border border-slate-700/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
+          <div className="bg-surface-overlay rounded-xl shadow-2xl border border-border-subtle/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-red-100 dark:bg-red-500/10 flex items-center justify-center">
+              <div className="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center">
                 <LogOut className="w-5 h-5 text-red-500" />
               </div>
-              <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">워크스페이스 나가기</h3>
+              <h3 className="text-lg font-bold text-text-primary">워크스페이스 나가기</h3>
             </div>
 
-            <p className="text-sm text-slate-500">
-              <span className="font-bold text-slate-700 dark:text-slate-300">{wsName}</span> 워크스페이스에서 나가시겠습니까? 다시 참여하려면 초대가 필요합니다.
+            <p className="text-sm text-text-faint">
+              <span className="font-bold text-text-secondary">{wsName}</span> 워크스페이스에서 나가시겠습니까? 다시 참여하려면 초대가 필요합니다.
             </p>
 
             {wsLeaveError && (
-              <p className="text-xs text-red-500 bg-red-50 dark:bg-red-500/10 rounded px-3 py-2">{wsLeaveError}</p>
+              <p className="text-xs text-red-500 bg-red-500/10 rounded px-3 py-2">{wsLeaveError}</p>
             )}
 
             <div className="flex justify-end gap-2 pt-2">
@@ -274,34 +274,34 @@ export const WsGeneralTab = () => {
       {/* 워크스페이스 삭제 모달 */}
       {showWsDeleteModal && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={() => !wsDeleting && setShowWsDeleteModal(false)}>
-          <div className="bg-white dark:bg-[#1e1e1e] rounded-xl shadow-2xl border border-slate-700/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
+          <div className="bg-surface-overlay rounded-xl shadow-2xl border border-border-subtle/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-red-100 dark:bg-red-500/10 flex items-center justify-center">
+              <div className="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center">
                 <AlertTriangle className="w-5 h-5 text-red-500" />
               </div>
-              <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">워크스페이스 삭제</h3>
+              <h3 className="text-lg font-bold text-text-primary">워크스페이스 삭제</h3>
             </div>
 
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-text-faint">
               이 작업은 되돌릴 수 없습니다. 워크스페이스의 모든 데이터가 영구 삭제됩니다.
             </p>
 
             <div>
-              <label className="block text-xs font-medium text-slate-500 mb-1.5">
-                확인을 위해 워크스페이스 이름(<span className="font-bold text-slate-700 dark:text-slate-300">{wsName}</span>)을 입력하세요
+              <label className="block text-xs font-medium text-text-faint mb-1.5">
+                확인을 위해 워크스페이스 이름(<span className="font-bold text-text-secondary">{wsName}</span>)을 입력하세요
               </label>
               <input
                 type="text"
                 value={wsDeleteConfirmName}
                 onChange={e => setWsDeleteConfirmName(e.target.value)}
                 placeholder={wsName}
-                className="w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded px-3 py-1.5 text-sm text-slate-900 dark:text-slate-200 focus:border-red-500 focus:ring-1 focus:ring-red-500 outline-none"
+                className="w-full bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm text-text-secondary focus:border-red-500 focus:ring-1 focus:ring-red-500 outline-none"
                 autoFocus
               />
             </div>
 
             {wsDeleteError && (
-              <p className="text-xs text-red-500 bg-red-50 dark:bg-red-500/10 rounded px-3 py-2">{wsDeleteError}</p>
+              <p className="text-xs text-red-500 bg-red-500/10 rounded px-3 py-2">{wsDeleteError}</p>
             )}
 
             <div className="flex justify-end gap-2 pt-2">

--- a/src/features/user/settings/WsImportTab.tsx
+++ b/src/features/user/settings/WsImportTab.tsx
@@ -4,43 +4,43 @@ import { FileUp } from 'lucide-react';
 export const WsImportTab = () => {
   return (
     <div className="space-y-8 animate-in fade-in duration-300">
-      <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100 pb-4 border-b border-slate-200 dark:border-slate-800">가져오기</h2>
+      <h2 className="text-xl font-bold text-text-primary pb-4 border-b border-border-default">가져오기</h2>
       <div className="space-y-4">
         <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4 flex items-start gap-3">
           <FileUp className="w-5 h-5 text-blue-500 mt-0.5" />
           <div>
-            <div className="text-sm font-bold text-slate-200">데이터 가져오기</div>
-            <div className="text-xs text-slate-500 mt-1">다른 앱의 데이터를 UJAX로 쉽게 이동하세요.</div>
+            <div className="text-sm font-bold text-text-secondary">데이터 가져오기</div>
+            <div className="text-xs text-text-faint mt-1">다른 앱의 데이터를 UJAX로 쉽게 이동하세요.</div>
           </div>
         </div>
 
         <div className="grid grid-cols-2 gap-4">
           <Button variant="secondary" className="justify-start gap-3 h-auto py-3">
-            <div className="w-8 h-8 bg-slate-200 dark:bg-slate-700 rounded flex items-center justify-center text-xs">Txt</div>
+            <div className="w-8 h-8 bg-surface-subtle rounded flex items-center justify-center text-xs">Txt</div>
             <div className="text-left">
               <div className="text-sm font-bold">Text & Markdown</div>
-              <div className="text-[10px] text-slate-500">파일 업로드</div>
+              <div className="text-[10px] text-text-faint">파일 업로드</div>
             </div>
           </Button>
           <Button variant="secondary" className="justify-start gap-3 h-auto py-3">
             <div className="w-8 h-8 bg-[#217346] rounded flex items-center justify-center text-white">Xls</div>
             <div className="text-left">
               <div className="text-sm font-bold">Excel</div>
-              <div className="text-[10px] text-slate-500">.xls, .xlsx</div>
+              <div className="text-[10px] text-text-faint">.xls, .xlsx</div>
             </div>
           </Button>
           <Button variant="secondary" className="justify-start gap-3 h-auto py-3">
             <div className="w-8 h-8 bg-[#4285F4] rounded flex items-center justify-center text-white">W</div>
             <div className="text-left">
               <div className="text-sm font-bold">Word</div>
-              <div className="text-[10px] text-slate-500">.docx</div>
+              <div className="text-[10px] text-text-faint">.docx</div>
             </div>
           </Button>
           <Button variant="secondary" className="justify-start gap-3 h-auto py-3">
             <div className="w-8 h-8 bg-[#E34F26] rounded flex items-center justify-center text-white">H</div>
             <div className="text-left">
               <div className="text-sm font-bold">HTML</div>
-              <div className="text-[10px] text-slate-500">.html</div>
+              <div className="text-[10px] text-text-faint">.html</div>
             </div>
           </Button>
         </div>

--- a/src/features/user/settings/WsMembersTab.tsx
+++ b/src/features/user/settings/WsMembersTab.tsx
@@ -125,18 +125,18 @@ export const WsMembersTab = () => {
 
   const roleBadgeClass = (role?: string) => {
     switch (role) {
-      case 'OWNER': return 'bg-amber-100 text-amber-700 dark:bg-amber-500/10 dark:text-amber-400';
-      case 'MANAGER': return 'bg-blue-100 text-blue-700 dark:bg-blue-500/10 dark:text-blue-400';
-      default: return 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400';
+      case 'OWNER': return 'bg-amber-500/10 text-amber-400';
+      case 'MANAGER': return 'bg-blue-500/10 text-blue-400';
+      default: return 'bg-surface-subtle text-text-muted';
     }
   };
 
   return (
     <div className="space-y-8 animate-in fade-in duration-300">
-      <div className="flex items-center justify-between pb-4 border-b border-slate-200 dark:border-slate-800">
+      <div className="flex items-center justify-between pb-4 border-b border-border-default">
         <div>
-          <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">멤버</h2>
-          <p className="text-sm text-slate-500 mt-1">워크스페이스의 멤버를 관리하세요.</p>
+          <h2 className="text-xl font-bold text-text-primary">멤버</h2>
+          <p className="text-sm text-text-faint mt-1">워크스페이스의 멤버를 관리하세요.</p>
         </div>
         <Button
           className="bg-emerald-600 hover:bg-emerald-700 text-white gap-2"
@@ -147,31 +147,31 @@ export const WsMembersTab = () => {
       </div>
 
       <div className="space-y-3">
-        <h3 className="text-sm font-bold text-slate-700 dark:text-slate-300">워크스페이스 멤버 ({members.length})</h3>
+        <h3 className="text-sm font-bold text-text-secondary">워크스페이스 멤버 ({members.length})</h3>
 
         {membersLoading ? (
-          <div className="text-sm text-slate-500 text-center py-8">불러오는 중...</div>
+          <div className="text-sm text-text-faint text-center py-8">불러오는 중...</div>
         ) : members.length === 0 ? (
-          <div className="text-sm text-slate-500 bg-slate-100 dark:bg-slate-800/50 p-4 rounded-lg text-center">
+          <div className="text-sm text-text-faint bg-surface-subtle/50 p-4 rounded-lg text-center">
             멤버가 없습니다.
           </div>
         ) : (
-          <div className="rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden divide-y divide-slate-200 dark:divide-slate-700">
+          <div className="rounded-lg border border-border-subtle overflow-hidden divide-y-2 divide-border-default">
             {members.map(member => {
               const isMe = member.workspaceMemberId === myMemberId;
               const role = member.role as string;
               const canManage = (myRole === 'OWNER' || myRole === 'MANAGER') && !isMe && role !== 'OWNER';
               const menuOpen = memberMenuOpen === member.workspaceMemberId;
               return (
-                <div key={member.workspaceMemberId} className="flex items-center justify-between py-3 px-4 bg-white dark:bg-[#1e1e1e] hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors">
+                <div key={member.workspaceMemberId} className="flex items-center justify-between py-3 px-4 bg-surface-overlay hover:bg-hover-bg transition-colors">
                   <div className="flex items-center gap-3">
-                    <div className="w-9 h-9 rounded-full bg-slate-200 dark:bg-slate-700 flex items-center justify-center">
-                      <span className="text-sm font-bold text-slate-500 dark:text-slate-400">
+                    <div className="w-9 h-9 rounded-full bg-surface-subtle flex items-center justify-center">
+                      <span className="text-sm font-bold text-text-muted">
                         {(member.nickname ?? '?').charAt(0).toUpperCase()}
                       </span>
                     </div>
                     <div>
-                      <div className="text-sm font-medium text-slate-900 dark:text-slate-200">
+                      <div className="text-sm font-medium text-text-secondary">
                         {member.nickname ?? '(닉네임 없음)'}
                       </div>
                     </div>
@@ -184,17 +184,17 @@ export const WsMembersTab = () => {
                       <div className="relative">
                         <button
                           onClick={() => setMemberMenuOpen(menuOpen ? null : member.workspaceMemberId!)}
-                          className="p-1 rounded hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+                          className="p-1 rounded hover:bg-hover-bg text-text-muted hover:text-text-secondary transition-colors"
                         >
                           <MoreHorizontal className="w-4 h-4" />
                         </button>
                         {menuOpen && (
                           <>
                             <div className="fixed inset-0 z-[150]" onClick={() => setMemberMenuOpen(null)} />
-                            <div className="absolute right-0 top-full mt-1 z-[151] w-48 bg-white dark:bg-[#252525] rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 py-1">
+                            <div className="absolute right-0 top-full mt-1 z-[151] w-48 bg-surface-overlay rounded-lg shadow-lg border border-border-subtle py-1">
                               {role !== 'MANAGER' && (
                                 <button
-                                  className="w-full text-left px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700"
+                                  className="w-full text-left px-3 py-2 text-sm text-text-secondary hover:bg-hover-bg"
                                   onClick={() => { setMemberMenuOpen(null); confirmRoleChange(member, 'MANAGER'); }}
                                 >
                                   매니저로 변경
@@ -202,7 +202,7 @@ export const WsMembersTab = () => {
                               )}
                               {role !== 'MEMBER' && (
                                 <button
-                                  className="w-full text-left px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700"
+                                  className="w-full text-left px-3 py-2 text-sm text-text-secondary hover:bg-hover-bg"
                                   onClick={() => { setMemberMenuOpen(null); confirmRoleChange(member, 'MEMBER'); }}
                                 >
                                   멤버로 변경
@@ -210,15 +210,15 @@ export const WsMembersTab = () => {
                               )}
                               {myRole === 'OWNER' && (
                                 <button
-                                  className="w-full text-left px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700"
+                                  className="w-full text-left px-3 py-2 text-sm text-text-secondary hover:bg-hover-bg"
                                   onClick={() => { setMemberMenuOpen(null); confirmRoleChange(member, 'OWNER'); }}
                                 >
                                   소유자로 변경
                                 </button>
                               )}
-                              <div className="border-t border-slate-200 dark:border-slate-700 my-1" />
+                              <div className="border-t border-border-subtle my-1" />
                               <button
-                                className="w-full text-left px-3 py-2 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10"
+                                className="w-full text-left px-3 py-2 text-sm text-red-500 hover:bg-red-500/10"
                                 onClick={() => { setMemberMenuOpen(null); confirmRemoveMember(member); }}
                               >
                                 워크스페이스에서 제거
@@ -239,32 +239,32 @@ export const WsMembersTab = () => {
       {/* 초대 모달 */}
       {showInviteModal && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={() => !inviting && setShowInviteModal(false)}>
-          <div className="bg-white dark:bg-[#1e1e1e] rounded-xl shadow-2xl border border-slate-700/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
+          <div className="bg-surface-overlay rounded-xl shadow-2xl border border-border-subtle/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-emerald-100 dark:bg-emerald-500/10 flex items-center justify-center">
+              <div className="w-10 h-10 rounded-full bg-emerald-500/10 flex items-center justify-center">
                 <UserPlus className="w-5 h-5 text-emerald-600" />
               </div>
-              <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">멤버 초대</h3>
+              <h3 className="text-lg font-bold text-text-primary">멤버 초대</h3>
             </div>
 
             <div>
-              <label className="block text-xs font-medium text-slate-500 mb-1.5">이메일 주소</label>
+              <label className="block text-xs font-medium text-text-faint mb-1.5">이메일 주소</label>
               <input
                 type="email"
                 value={inviteEmail}
                 onChange={e => setInviteEmail(e.target.value)}
                 placeholder="example@email.com"
-                className="w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded px-3 py-1.5 text-sm text-slate-900 dark:text-slate-200 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                className="w-full bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm text-text-secondary focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
                 autoFocus
                 onKeyDown={e => e.key === 'Enter' && inviteEmail.trim() && handleInvite()}
               />
             </div>
 
             {inviteError && (
-              <p className="text-xs text-red-500 bg-red-50 dark:bg-red-500/10 rounded px-3 py-2">{inviteError}</p>
+              <p className="text-xs text-red-500 bg-red-500/10 rounded px-3 py-2">{inviteError}</p>
             )}
             {inviteSuccess && (
-              <p className="text-xs text-emerald-600 bg-emerald-50 dark:bg-emerald-500/10 rounded px-3 py-2">초대가 완료되었습니다.</p>
+              <p className="text-xs text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 rounded px-3 py-2">초대가 완료되었습니다.</p>
             )}
 
             <div className="flex justify-end gap-2 pt-2">
@@ -284,15 +284,15 @@ export const WsMembersTab = () => {
       {/* 역할 변경 확인 모달 */}
       {showRoleChangeModal && roleChangeMember && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={() => !roleChangeLoading && setShowRoleChangeModal(false)}>
-          <div className="bg-white dark:bg-[#1e1e1e] rounded-xl shadow-2xl border border-slate-700/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
-            <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">역할 변경</h3>
-            <p className="text-sm text-slate-500">
-              <span className="font-bold text-slate-700 dark:text-slate-300">{roleChangeMember.nickname}</span>의 역할을{' '}
-              <span className="font-bold text-slate-700 dark:text-slate-300">{roleLabel(roleChangeTarget)}</span>(으)로 변경하시겠습니까?
+          <div className="bg-surface-overlay rounded-xl shadow-2xl border border-border-subtle/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
+            <h3 className="text-lg font-bold text-text-primary">역할 변경</h3>
+            <p className="text-sm text-text-faint">
+              <span className="font-bold text-text-secondary">{roleChangeMember.nickname}</span>의 역할을{' '}
+              <span className="font-bold text-text-secondary">{roleLabel(roleChangeTarget)}</span>(으)로 변경하시겠습니까?
             </p>
 
             {roleChangeError && (
-              <p className="text-xs text-red-500 bg-red-50 dark:bg-red-500/10 rounded px-3 py-2">{roleChangeError}</p>
+              <p className="text-xs text-red-500 bg-red-500/10 rounded px-3 py-2">{roleChangeError}</p>
             )}
 
             <div className="flex justify-end gap-2 pt-2">
@@ -312,19 +312,19 @@ export const WsMembersTab = () => {
       {/* 멤버 제거 확인 모달 */}
       {showRemoveMemberModal && removingMember && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={() => !removingLoading && setShowRemoveMemberModal(false)}>
-          <div className="bg-white dark:bg-[#1e1e1e] rounded-xl shadow-2xl border border-slate-700/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
+          <div className="bg-surface-overlay rounded-xl shadow-2xl border border-border-subtle/50 w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-red-100 dark:bg-red-500/10 flex items-center justify-center">
+              <div className="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center">
                 <AlertTriangle className="w-5 h-5 text-red-500" />
               </div>
-              <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">멤버 제거</h3>
+              <h3 className="text-lg font-bold text-text-primary">멤버 제거</h3>
             </div>
-            <p className="text-sm text-slate-500">
-              <span className="font-bold text-slate-700 dark:text-slate-300">{removingMember.nickname}</span>을(를) 워크스페이스에서 제거하시겠습니까? 이 멤버는 더 이상 워크스페이스에 접근할 수 없습니다.
+            <p className="text-sm text-text-faint">
+              <span className="font-bold text-text-secondary">{removingMember.nickname}</span>을(를) 워크스페이스에서 제거하시겠습니까? 이 멤버는 더 이상 워크스페이스에 접근할 수 없습니다.
             </p>
 
             {removeMemberError && (
-              <p className="text-xs text-red-500 bg-red-50 dark:bg-red-500/10 rounded px-3 py-2">{removeMemberError}</p>
+              <p className="text-xs text-red-500 bg-red-500/10 rounded px-3 py-2">{removeMemberError}</p>
             )}
 
             <div className="flex justify-end gap-2 pt-2">

--- a/src/index.css
+++ b/src/index.css
@@ -1,46 +1,4 @@
 @import "tailwindcss";
+@import "./styles/globals.css";
 @config "../tailwind.config.js";
 @plugin "@tailwindcss/typography";
-
-@layer base {
-  :root {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    --radius: 0.5rem;
-  }
-}
-
-@layer base {
-  * {
-    @apply border-border;
-  }
-
-  body {
-    @apply bg-background text-foreground;
-  }
-}

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -1,9 +1,24 @@
 import { atom, AtomEffect } from 'recoil';
 
+const localStorageEffect = <T>(key: string): AtomEffect<T> => ({ setSelf, onSet }) => {
+  try {
+    const saved = localStorage.getItem(key);
+    if (saved != null) setSelf(JSON.parse(saved));
+  } catch { /* ignore */ }
+  onSet((newValue, _, isReset) => {
+    try {
+      if (isReset) localStorage.removeItem(key);
+      else localStorage.setItem(key, JSON.stringify(newValue));
+    } catch { /* ignore */ }
+  });
+};
 
-export const themeState = atom({
+export type ThemeMode = 'system' | 'light' | 'dark';
+
+export const themeState = atom<ThemeMode>({
   key: 'themeState',
   default: 'dark',
+  effects: [localStorageEffect('theme')],
 });
 
 export const sidebarOpenState = atom({
@@ -24,6 +39,7 @@ export interface ProblemBox {
 export const currentProblemBoxState = atom<ProblemBox | null>({
   key: 'currentProblemBoxState',
   default: null, // null이면 문제집 목록 표시, 값이 있으면 해당 문제집 내부 표시
+  effects: [localStorageEffect('currentProblemBox')],
 });
 
 // IDE State
@@ -127,19 +143,6 @@ export interface Workspace {
   name: string;
   description: string | null;
 }
-
-const localStorageEffect = <T>(key: string): AtomEffect<T> => ({ setSelf, onSet }) => {
-  try {
-    const saved = localStorage.getItem(key);
-    if (saved != null) setSelf(JSON.parse(saved));
-  } catch { /* ignore */ }
-  onSet((newValue, _, isReset) => {
-    try {
-      if (isReset) localStorage.removeItem(key);
-      else localStorage.setItem(key, JSON.stringify(newValue));
-    } catch { /* ignore */ }
-  });
-};
 
 export const currentWorkspaceState = atom<number>({
   key: 'currentWorkspaceState',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -39,6 +39,23 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+
+  /* Semantic colors — light */
+  --page: #ffffff;
+  --page-deep: #fcfcfd;
+  --surface: #ffffff;
+  --surface-raised: #ffffff;
+  --surface-overlay: #ffffff;
+  --surface-inset: #f8f9fb;
+  --surface-subtle: #f3f5f8;
+  --text-primary: #0f172a;
+  --text-secondary: #2d3748;
+  --text-muted: #4a5568;
+  --text-faint: #718096;
+  --border-default: rgba(0, 0, 0, 0.15);
+  --border-subtle: #b8c1cc;
+  --input-bg: #f8f9fb;
+  --hover-bg: rgba(0, 0, 0, 0.04);
 }
 
 .dark {
@@ -76,6 +93,23 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(0.269 0 0);
   --sidebar-ring: oklch(0.439 0 0);
+
+  /* Semantic colors — dark */
+  --page: #0F1117;
+  --page-deep: #0a0c10;
+  --surface: #141820;
+  --surface-raised: #151922;
+  --surface-overlay: #1e1e1e;
+  --surface-inset: #1b202c;
+  --surface-subtle: #1e2330;
+  --text-primary: #f1f5f9;
+  --text-secondary: #cbd5e1;
+  --text-muted: #94a3b8;
+  --text-faint: #64748b;
+  --border-default: #1e293b;
+  --border-subtle: #334155;
+  --input-bg: #0f172a;
+  --hover-bg: rgba(30, 41, 59, 0.5);
 }
 
 @theme inline {
@@ -117,6 +151,23 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+
+  /* Semantic colors */
+  --color-page: var(--page);
+  --color-page-deep: var(--page-deep);
+  --color-surface: var(--surface);
+  --color-surface-raised: var(--surface-raised);
+  --color-surface-overlay: var(--surface-overlay);
+  --color-surface-inset: var(--surface-inset);
+  --color-surface-subtle: var(--surface-subtle);
+  --color-text-primary: var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
+  --color-text-muted: var(--text-muted);
+  --color-text-faint: var(--text-faint);
+  --color-border-default: var(--border-default);
+  --color-border-subtle: var(--border-subtle);
+  --color-input-bg: var(--input-bg);
+  --color-hover-bg: var(--hover-bg);
 }
 
 @layer base {


### PR DESCRIPTION
- CSS Custom Properties 기반 시맨틱 색상 시스템 구축 (globals.css)
- Tailwind @theme inline으로 시맨틱 클래스 매핑 (bg-page, bg-surface, text-text-primary 등)
- 전체 37개 파일의 하드코딩 hex 색상을 시맨틱 토큰으로 교체
- Settings > 기본 설정에서 라이트/다크/시스템 테마 전환 지원
- Monaco Editor 테마 연동 (vs-dark/light)
- 로그인/로그아웃 시 마지막 워크스페이스 ID를 localStorage에 유지