### PR TITLE
refactor: useAuth 훅 도입 및 상태 관리 개선

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -9,7 +9,7 @@ import {
   settingsTabState,
   isCreateWorkspaceModalOpenState
 } from '@/store/atoms';
-import { logoutApi } from '@/api/auth';
+import { useAuth } from '@/hooks/useAuth';
 import {
   LayoutDashboard,
   BookOpen,
@@ -38,7 +38,8 @@ export const Sidebar = () => {
   const [workspaces, setWorkspaces] = useRecoilState(workspacesState);
   const [currentWorkspaceId, setCurrentWorkspaceId] = useRecoilState(currentWorkspaceState);
   const setIsCreateWorkspaceModalOpen = useSetRecoilState(isCreateWorkspaceModalOpenState);
-  const [user, setUser] = useRecoilState(userState);
+  const [user] = useRecoilState(userState);
+  const { logout } = useAuth();
 
   const [isWorkspaceMenuOpen, setIsWorkspaceMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -55,19 +56,7 @@ export const Sidebar = () => {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  const handleLogout = async () => {
-    try {
-      if (user.refreshToken) {
-        await logoutApi(user.refreshToken);
-      }
-    } catch {
-      // logout API 실패해도 로컬 상태는 초기화
-    }
-    localStorage.removeItem('auth');
-    setUser({ isLoggedIn: false, id: 0, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' });
-    setWorkspaces([]);
-    navigate('/login');
-  };
+  const handleLogout = () => logout(user.refreshToken);
 
   // 메뉴 항목의 path는 wsId 없이 상대 경로만 정의
   // 실제 navigate 시 /ws/:wsId/ 접두사를 붙여줌

--- a/src/components/modals/CreateWorkspaceModal.tsx
+++ b/src/components/modals/CreateWorkspaceModal.tsx
@@ -7,6 +7,7 @@ import { Button } from '../ui/Base';
 import { X, Check } from 'lucide-react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
+import { parseApiError } from '@/utils/error';
 
 export const CreateWorkspaceModal = () => {
   const [isOpen, setIsOpen] = useRecoilState(isCreateWorkspaceModalOpenState);
@@ -46,7 +47,7 @@ export const CreateWorkspaceModal = () => {
       setDescription('');
       navigate(`/ws/${newWorkspace.id}/dashboard`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : '워크스페이스 생성에 실패했습니다.');
+      setError(parseApiError(err, '워크스페이스 생성에 실패했습니다.'));
     } finally {
       setIsSubmitting(false);
     }

--- a/src/features/auth/Login.tsx
+++ b/src/features/auth/Login.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
-import { useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import { useT } from '@/i18n';
-import { userState, workspacesState } from '@/store/atoms';
 import { loginApi } from '@/api/auth';
-import { getMe } from '@/api/user';
 import { Button, Card } from '@/components/ui/Base';
 import { Mail, Lock, MessageCircle } from 'lucide-react';
+import { parseApiError } from '@/utils/error';
+import { useAuth } from '@/hooks/useAuth';
 
 interface LoginProps {
   oauthError?: string;
@@ -16,8 +15,7 @@ interface LoginProps {
 export const Login = ({ oauthError, onClearError }: LoginProps) => {
   const navigate = useNavigate();
   const t = useT();
-  const setUser = useSetRecoilState(userState);
-  const setWorkspaces = useSetRecoilState(workspacesState);
+  const { setAuthUser } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -35,36 +33,12 @@ export const Login = ({ oauthError, onClearError }: LoginProps) => {
     try {
       const result = await loginApi(email, password);
       const { accessToken, refreshToken } = result.data;
-
-      // 토큰을 먼저 저장 (getMe가 authFetch를 사용하므로)
-      localStorage.setItem('auth', JSON.stringify({ accessToken, refreshToken }));
-
-      // getMe()로 완전한 유저 정보 조회
-      const me = await getMe();
-
-      const userData = {
-        isLoggedIn: true,
-        id: me.id,
-        name: me.name,
-        email: me.email,
-        avatar: me.name,
-        profileImageUrl: me.profileImageUrl ?? '',
-        baekjoonId: me.baekjoonId ?? '',
-        provider: me.provider,
-        accessToken: accessToken!,
-        refreshToken: refreshToken!,
-      };
-
-      localStorage.setItem('auth', JSON.stringify(userData));
-
-      setWorkspaces([]);
-      setUser(userData);
-
+      await setAuthUser(accessToken, refreshToken);
       setLoading(false);
       navigate('/');
     } catch (err: any) {
       console.error('Login error', err);
-      setError(err.message || '로그인에 실패했습니다.');
+      setError(parseApiError(err, '로그인에 실패했습니다.'));
     } finally {
       setLoading(false);
     }

--- a/src/features/auth/OAuthCallback.tsx
+++ b/src/features/auth/OAuthCallback.tsx
@@ -1,16 +1,13 @@
 import { useRef, useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
-import { userState, workspacesState } from '@/store/atoms';
-import { getMe } from '@/api/user';
+import { useAuth } from '@/hooks/useAuth';
 
 interface Props {
   onComplete?: (error?: string) => void;
 }
 
 export const OAuthCallback = ({ onComplete }: Props) => {
-  const setUser = useSetRecoilState(userState);
-  const setWorkspaces = useSetRecoilState(workspacesState);
+  const { setAuthUser } = useAuth();
   const navigate = useNavigate();
   // Use a ref to prevent double execution in strict mode
   const processedRef = useRef(false);
@@ -39,29 +36,7 @@ export const OAuthCallback = ({ onComplete }: Props) => {
     if (accessToken && refreshToken) {
       (async () => {
         try {
-          // 토큰을 먼저 저장 (getMe가 authFetch를 사용하므로)
-          localStorage.setItem('auth', JSON.stringify({ accessToken, refreshToken }));
-
-          // getMe()로 완전한 유저 정보 조회
-          const me = await getMe();
-
-          const userData = {
-            isLoggedIn: true,
-            id: me.id,
-            name: me.name,
-            email: me.email,
-            avatar: me.name,
-            profileImageUrl: me.profileImageUrl ?? '',
-            baekjoonId: me.baekjoonId ?? '',
-            provider: me.provider,
-            accessToken,
-            refreshToken,
-          };
-
-          localStorage.setItem('auth', JSON.stringify(userData));
-          setWorkspaces([]);
-          setUser(userData);
-
+          await setAuthUser(accessToken, refreshToken);
           navigate('/', { replace: true });
           if (onComplete) onComplete();
         } catch {

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -1,19 +1,16 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
 import { useT } from '@/i18n';
-import { userState, workspacesState, currentWorkspaceState } from '@/store/atoms';
 import { signupApi } from '@/api/auth';
-import { getMe } from '@/api/user';
 import { Button, Card } from '@/components/ui/Base';
 import { Mail, Lock, User, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { parseApiError } from '@/utils/error';
+import { useAuth } from '@/hooks/useAuth';
 
 export const SignUp = () => {
   const navigate = useNavigate();
   const t = useT();
-  const setUser = useSetRecoilState(userState);
-  const setWorkspaces = useSetRecoilState(workspacesState);
-  const setCurrentWsId = useSetRecoilState(currentWorkspaceState);
+  const { setAuthUser } = useAuth();
   const [formData, setFormData] = useState({
     email: '',
     password: '',
@@ -53,36 +50,11 @@ export const SignUp = () => {
     try {
       const result = await signupApi(formData.email, formData.password, formData.nickname);
       const { accessToken, refreshToken } = result.data;
-
-      // 토큰을 먼저 저장 (getMe가 authFetch를 사용하므로)
-      localStorage.setItem('auth', JSON.stringify({ accessToken, refreshToken }));
-
-      // getMe()로 완전한 유저 정보 조회
-      const me = await getMe();
-
-      const userData = {
-        isLoggedIn: true,
-        id: me.id,
-        name: me.name,
-        email: me.email,
-        avatar: me.name,
-        profileImageUrl: me.profileImageUrl ?? '',
-        baekjoonId: me.baekjoonId ?? '',
-        provider: me.provider,
-        accessToken: accessToken!,
-        refreshToken: refreshToken!,
-      };
-
-      localStorage.setItem('auth', JSON.stringify(userData));
-
-      setWorkspaces([]);
-      setCurrentWsId(0);
-      setUser(userData);
-
+      await setAuthUser(accessToken, refreshToken);
       navigate('/');
     } catch (err: any) {
       console.error('Signup error', err);
-      setApiError(err.message || '회원가입에 실패했습니다.');
+      setApiError(parseApiError(err, '회원가입에 실패했습니다.'));
     } finally {
       setLoading(false);
     }

--- a/src/features/community/PostCreate.tsx
+++ b/src/features/community/PostCreate.tsx
@@ -8,6 +8,7 @@ import type { MemberRole } from '@/api/board';
 import { getMyMembership } from '@/api/workspace';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { parseApiError } from '@/utils/error';
 import { useT } from '@/i18n';
 import {
   PenSquare,
@@ -184,18 +185,7 @@ export const PostCreate = () => {
       });
       toWs('community');
     } catch (err: any) {
-      const msg = err?.message || '';
-      const jsonMatch = msg.match(/\{[\s\S]*\}/);
-      if (jsonMatch) {
-        try {
-          const parsed = JSON.parse(jsonMatch[0]);
-          setError(parsed.detail || t('common.error'));
-        } catch {
-          setError(t('common.error'));
-        }
-      } else {
-        setError(t('common.error'));
-      }
+      setError(parseApiError(err, t('common.error')));
     } finally {
       setSubmitting(false);
     }

--- a/src/features/community/PostDetail.tsx
+++ b/src/features/community/PostDetail.tsx
@@ -4,6 +4,7 @@ import { useRecoilValue } from 'recoil';
 import { currentWorkspaceState } from '@/store/atoms';
 import { useWorkspaceNavigate } from '@/hooks/useWorkspaceNavigate';
 import { Card, Button, Badge } from '@/components/ui/Base';
+import { parseApiError } from '@/utils/error';
 import {
   getBoardDetail,
   likeBoard,
@@ -111,12 +112,7 @@ export const PostDetail = () => {
       await loadComments(0);
       setPost(prev => prev ? { ...prev, commentCount: (prev.commentCount ?? 0) + 1 } : prev);
     } catch (err: any) {
-      const msg = err?.message || '';
-      const jsonMatch = msg.match(/\{[\s\S]*\}/);
-      if (jsonMatch) {
-        try { alert(JSON.parse(jsonMatch[0]).detail || t('common.error')); }
-        catch { alert(t('common.error')); }
-      } else { alert(t('common.error')); }
+      alert(parseApiError(err, t('common.error')));
     } finally {
       setCommentSubmitting(false);
     }
@@ -137,12 +133,7 @@ export const PostDetail = () => {
       await deleteBoard(wsId, numericBoardId);
       toWs('community');
     } catch (err: any) {
-      const msg = err?.message || '';
-      const jsonMatch = msg.match(/\{[\s\S]*\}/);
-      if (jsonMatch) {
-        try { alert(JSON.parse(jsonMatch[0]).detail || t('common.error')); }
-        catch { alert(t('common.error')); }
-      } else { alert(t('common.error')); }
+      alert(parseApiError(err, t('common.error')));
     }
   };
 
@@ -152,12 +143,7 @@ export const PostDetail = () => {
       await pinBoard(wsId, numericBoardId, !post.pinned);
       setPost(prev => prev ? { ...prev, pinned: !prev.pinned } : prev);
     } catch (err: any) {
-      const msg = err?.message || '';
-      const jsonMatch = msg.match(/\{[\s\S]*\}/);
-      if (jsonMatch) {
-        try { alert(JSON.parse(jsonMatch[0]).detail || t('common.error')); }
-        catch { alert(t('common.error')); }
-      } else { alert(t('common.error')); }
+      alert(parseApiError(err, t('common.error')));
     }
   };
 

--- a/src/features/community/PostEdit.tsx
+++ b/src/features/community/PostEdit.tsx
@@ -8,6 +8,7 @@ import { getBoardDetail, updateBoard, LABEL_TO_BOARD_TYPE } from '@/api/board';
 import type { MemberRole } from '@/api/board';
 import { useT } from '@/i18n';
 import { getMyMembership } from '@/api/workspace';
+import { parseApiError } from '@/utils/error';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -203,18 +204,7 @@ export const PostEdit = () => {
       });
       toWs(`community/${numericBoardId}`);
     } catch (err: any) {
-      const msg = err?.message || '';
-      const jsonMatch = msg.match(/\{[\s\S]*\}/);
-      if (jsonMatch) {
-        try {
-          const parsed = JSON.parse(jsonMatch[0]);
-          setError(parsed.detail || t('common.error'));
-        } catch {
-          setError(t('common.error'));
-        }
-      } else {
-        setError(t('common.error'));
-      }
+      setError(parseApiError(err, t('common.error')));
     } finally {
       setSubmitting(false);
     }

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -3,16 +3,17 @@ import { useNavigate, Navigate } from 'react-router-dom';
 import { useRecoilValue, useRecoilState, useSetRecoilState } from 'recoil';
 import { userState, workspacesState, currentWorkspaceState, isCreateWorkspaceModalOpenState, Workspace } from '@/store/atoms';
 import { getWorkspaces } from '@/api/workspace';
-import { logoutApi } from '@/api/auth';
 import { Button, Card } from '@/components/ui/Base';
+import { useAuth } from '@/hooks/useAuth';
 import { Code2, Users, Zap, Layout, Monitor, Search, LogOut, Settings, ChevronDown } from 'lucide-react';
 import { useT } from '@/i18n';
 
 export const Home = () => {
     const navigate = useNavigate();
     const t = useT();
-    const [user, setUser] = useRecoilState(userState);
+    const [user] = useRecoilState(userState);
     const [workspaces, setWorkspaces] = useRecoilState(workspacesState);
+    const { logout } = useAuth();
     const currentWsId = useRecoilValue(currentWorkspaceState);
     const setCreateWorkspaceOpen = useSetRecoilState(isCreateWorkspaceModalOpenState);
     const [exploreQuery, setExploreQuery] = useState('');
@@ -32,18 +33,8 @@ export const Home = () => {
     }, []);
 
     const handleLogout = async () => {
-        try {
-            if (user.refreshToken) {
-                await logoutApi(user.refreshToken);
-            }
-        } catch {
-            // logout API 실패해도 로컬 상태는 초기화
-        }
-        localStorage.removeItem('auth');
-        setUser({ isLoggedIn: false, id: 0, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' });
-        setWorkspaces([]);
         setProfileMenuOpen(false);
-        navigate('/login');
+        await logout(user.refreshToken);
     };
 
     // 로그인 상태에서 워크스페이스 목록 fetch

--- a/src/features/ide/IDE.tsx
+++ b/src/features/ide/IDE.tsx
@@ -13,6 +13,7 @@ import { createSubmission, getSubmissionResults } from '@/api/submission';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { useIsDark } from '@/App';
 import { useExtensionProblemContext } from '@/hooks/useExtensionProblemContext';
+import { parseApiError } from '@/utils/error';
 
 // Language ID mapping for Judge0
 const LANGUAGE_OPTIONS = [
@@ -103,20 +104,6 @@ const Stopwatch = () => {
   );
 };
 
-// ─── Helper: parse error detail per CLAUDE.md ───
-function parseErrorDetail(err: any): string {
-  const msg = err?.message || '';
-  const jsonMatch = msg.match(/\{[\s\S]*\}/);
-  if (jsonMatch) {
-    try {
-      const parsed = JSON.parse(jsonMatch[0]);
-      return parsed.detail || '요청에 실패했습니다.';
-    } catch {
-      return '요청에 실패했습니다.';
-    }
-  }
-  return '요청에 실패했습니다.';
-}
 
 export const IDE = () => {
   const isDark = useIsDark();
@@ -179,7 +166,7 @@ export const IDE = () => {
         if (sampleCases.length > 0) setSelectedCaseId(sampleCases[0].id);
       })
       .catch((err) => {
-        setProblemError(parseErrorDetail(err));
+        setProblemError(parseApiError(err));
       })
       .finally(() => setProblemLoading(false));
   }, [problemId]);

--- a/src/features/problems/ProblemList.tsx
+++ b/src/features/problems/ProblemList.tsx
@@ -17,6 +17,7 @@ import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@
 import { useT, useLang } from '@/i18n';
 import { useExtensionBatchContext } from '@/hooks/useExtensionProblemContext';
 import { useSolutionPolling } from '@/hooks/useSolutionPolling';
+import { parseApiError } from '@/utils/error';
 
 type MemberRole = 'OWNER' | 'ADMIN' | 'MANAGER' | 'MEMBER';
 
@@ -36,18 +37,6 @@ function relativeTime(dateStr: string, t: (key: string, vars?: Record<string, st
   const months = Math.floor(days / 30);
   if (months < 12) return t('time.monthsAgo', { n: months });
   return t('time.yearsAgo', { n: Math.floor(months / 12) });
-}
-
-function parseApiError(err: any, fallback: string): string {
-  const msg = err?.message || '';
-  const jsonMatch = msg.match(/\{[\s\S]*\}/);
-  if (jsonMatch) {
-    try {
-      const parsed = JSON.parse(jsonMatch[0]);
-      return parsed.detail || fallback;
-    } catch { /* ignore */ }
-  }
-  return fallback;
 }
 
 export const ProblemList = () => {

--- a/src/features/problems/ProblemRegistration.tsx
+++ b/src/features/problems/ProblemRegistration.tsx
@@ -13,20 +13,9 @@ import dayjs, { Dayjs } from 'dayjs';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { useT } from '@/i18n';
+import { parseApiError } from '@/utils/error';
 
 type FlowStatus = 'idle' | 'loading' | 'found' | 'crawling' | 'registering' | 'done' | 'error' | 'timeout';
-
-function parseApiError(err: any): { detail: string; status?: number } {
-  const msg = err?.message || '';
-  const jsonMatch = msg.match(/\{[\s\S]*\}/);
-  if (jsonMatch) {
-    try {
-      const parsed = JSON.parse(jsonMatch[0]);
-      return { detail: parsed.detail || '요청에 실패했습니다.', status: parsed.status };
-    } catch { /* ignore */ }
-  }
-  return { detail: '요청에 실패했습니다.' };
-}
 
 export const ProblemRegistration = () => {
   const { toWs, currentWsId } = useWorkspaceNavigate();
@@ -105,7 +94,7 @@ export const ProblemRegistration = () => {
         requestCrawl(num);
       }
     } catch (err: any) {
-      const { detail } = parseApiError(err);
+      const detail = parseApiError(err);
       setFlowStatus('error');
       setErrorMsg(detail);
     }
@@ -134,7 +123,7 @@ export const ProblemRegistration = () => {
       });
       setFlowStatus('done');
     } catch (err: any) {
-      const { detail } = parseApiError(err);
+      const detail = parseApiError(err);
       setFlowStatus('error');
       setErrorMsg(detail);
     }

--- a/src/features/user/Settings.tsx
+++ b/src/features/user/Settings.tsx
@@ -29,30 +29,15 @@ export const Settings = () => {
   const [user, setUser] = useRecoilState(userState);
   const t = useT();
 
-  // 설정 진입 시 최신 프로필 데이터로 Recoil/localStorage 동기화
+  // 설정 진입 시 최신 프로필 데이터로 Recoil 동기화 (localStorage는 atom effect가 자동 처리)
   useEffect(() => {
     getMe().then(data => {
-      setUser(prev => {
-        const next = {
-          ...prev,
-          name: data.name,
-          profileImageUrl: data.profileImageUrl ?? '',
-          baekjoonId: data.baekjoonId ?? '',
-        };
-        try {
-          const stored = localStorage.getItem('auth');
-          if (stored) {
-            const parsed = JSON.parse(stored);
-            localStorage.setItem('auth', JSON.stringify({
-              ...parsed,
-              name: next.name,
-              profileImageUrl: next.profileImageUrl,
-              baekjoonId: next.baekjoonId,
-            }));
-          }
-        } catch { /* ignore */ }
-        return next;
-      });
+      setUser(prev => ({
+        ...prev,
+        name: data.name,
+        profileImageUrl: data.profileImageUrl ?? '',
+        baekjoonId: data.baekjoonId ?? '',
+      }));
     }).catch(() => { /* ignore - ProfileTab will also fetch */ });
   }, [setUser]);
 

--- a/src/features/user/settings/ProfileTab.tsx
+++ b/src/features/user/settings/ProfileTab.tsx
@@ -1,18 +1,16 @@
 import { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/Base';
-import { useRecoilState, useSetRecoilState } from 'recoil';
-import { useNavigate } from 'react-router-dom';
-import { userState, workspacesState, currentWorkspaceState } from '@/store/atoms';
+import { useRecoilState } from 'recoil';
+import { userState } from '@/store/atoms';
 import { getMe, updateMe, deleteMe, getProfileImagePresignedUrl } from '@/api/user';
-import { extractErrorDetail } from './utils';
+import { parseApiError } from '@/utils/error';
 import { AlertTriangle } from 'lucide-react';
 import { useT } from '@/i18n';
+import { useAuth } from '@/hooks/useAuth';
 
 export const ProfileTab = () => {
-  const navigate = useNavigate();
   const [user, setUser] = useRecoilState(userState);
-  const setWorkspaces = useSetRecoilState(workspacesState);
-  const setCurrentWorkspaceId = useSetRecoilState(currentWorkspaceState);
+  const { logout } = useAuth();
 
   // Profile form state
   const [name, setName] = useState('');
@@ -48,32 +46,16 @@ export const ProfileTab = () => {
       setOriginalName(data.name);
       setOriginalBaekjoonId(data.baekjoonId ?? '');
       setOriginalImageUrl(data.profileImageUrl ?? '');
-      // Recoil + localStorage도 동기화
-      setUser(prev => {
-        const next = {
-          ...prev,
-          id: data.id,
-          name: data.name,
-          email: data.email,
-          profileImageUrl: data.profileImageUrl ?? '',
-          baekjoonId: data.baekjoonId ?? '',
-          provider: data.provider,
-        };
-        try {
-          const stored = localStorage.getItem('auth');
-          if (stored) {
-            const parsed = JSON.parse(stored);
-            localStorage.setItem('auth', JSON.stringify({
-              ...parsed,
-              id: next.id,
-              name: next.name,
-              profileImageUrl: next.profileImageUrl,
-              baekjoonId: next.baekjoonId,
-            }));
-          }
-        } catch { /* ignore */ }
-        return next;
-      });
+      // Recoil 업데이트 → authStorageEffect가 localStorage 자동 동기화
+      setUser(prev => ({
+        ...prev,
+        id: data.id,
+        name: data.name,
+        email: data.email,
+        profileImageUrl: data.profileImageUrl ?? '',
+        baekjoonId: data.baekjoonId ?? '',
+        provider: data.provider,
+      }));
     }).catch(err => {
       console.error('Failed to load profile:', err);
     });
@@ -146,28 +128,13 @@ export const ProfileTab = () => {
       }
 
       const updated = await updateMe(requestBody);
-      // API 성공 → Recoil + localStorage 동기화
-      setUser(prev => {
-        const next = {
-          ...prev,
-          name: updated.name,
-          profileImageUrl: updated.profileImageUrl ?? '',
-          baekjoonId: updated.baekjoonId ?? '',
-        };
-        try {
-          const stored = localStorage.getItem('auth');
-          if (stored) {
-            const parsed = JSON.parse(stored);
-            localStorage.setItem('auth', JSON.stringify({
-              ...parsed,
-              name: next.name,
-              profileImageUrl: next.profileImageUrl,
-              baekjoonId: next.baekjoonId,
-            }));
-          }
-        } catch { /* ignore */ }
-        return next;
-      });
+      // Recoil 업데이트 → authStorageEffect가 localStorage 자동 동기화
+      setUser(prev => ({
+        ...prev,
+        name: updated.name,
+        profileImageUrl: updated.profileImageUrl ?? '',
+        baekjoonId: updated.baekjoonId ?? '',
+      }));
       setProfileImageUrl(updated.profileImageUrl ?? '');
       setPreviewUrl('');
       setPendingFile(null);
@@ -181,7 +148,7 @@ export const ProfileTab = () => {
     } catch (err: any) {
       console.error('Failed to save profile:', err);
       setSaveResult('error');
-      setSaveError(extractErrorDetail(err, '요청에 실패했습니다.'));
+      setSaveError(parseApiError(err, '요청에 실패했습니다.'));
     } finally {
       setSaving(false);
       setTimeout(() => setSaveResult(null), 3000);
@@ -193,13 +160,9 @@ export const ProfileTab = () => {
     setDeleteError('');
     try {
       await deleteMe();
-      localStorage.removeItem('auth');
-      setUser({ isLoggedIn: false, id: 0, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' });
-      setWorkspaces([]);
-      setCurrentWorkspaceId(0);
-      navigate('/login');
+      await logout();
     } catch (err: any) {
-      setDeleteError(extractErrorDetail(err, '계정 삭제에 실패했습니다.'));
+      setDeleteError(parseApiError(err, '계정 삭제에 실패했습니다.'));
     } finally {
       setDeleting(false);
     }

--- a/src/features/user/settings/WsGeneralTab.tsx
+++ b/src/features/user/settings/WsGeneralTab.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/Base';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { currentWorkspaceState, workspacesState, settingsTabState } from '@/store/atoms';
 import { getWorkspaceSettings, updateWorkspace, deleteWorkspace, leaveWorkspace, getMyMembership, updateMyNickname, getWorkspaceImagePresignedUrl } from '@/api/workspace';
-import { extractErrorDetail } from './utils';
+import { parseApiError } from '@/utils/error';
 import { AlertTriangle, LogOut } from 'lucide-react';
 import { useT } from '@/i18n';
 
@@ -156,7 +156,7 @@ export const WsGeneralTab = () => {
       setWsSaveResult('success');
     } catch (err: any) {
       setWsSaveResult('error');
-      setWsSaveError(extractErrorDetail(err, '저장에 실패했습니다.'));
+      setWsSaveError(parseApiError(err, '저장에 실패했습니다.'));
     } finally {
       setWsSaving(false);
       setTimeout(() => setWsSaveResult(null), 3000);
@@ -180,7 +180,7 @@ export const WsGeneralTab = () => {
       setWsNickSaveResult('success');
     } catch (err: any) {
       setWsNickSaveResult('error');
-      setWsNickSaveError(extractErrorDetail(err, '닉네임 저장에 실패했습니다.'));
+      setWsNickSaveError(parseApiError(err, '닉네임 저장에 실패했습니다.'));
     } finally {
       setWsNickSaving(false);
       setTimeout(() => setWsNickSaveResult(null), 3000);
@@ -199,7 +199,7 @@ export const WsGeneralTab = () => {
       setShowWsDeleteModal(false);
       setActiveTab('profile');
     } catch (err: any) {
-      setWsDeleteError(extractErrorDetail(err, '워크스페이스 삭제에 실패했습니다.'));
+      setWsDeleteError(parseApiError(err, '워크스페이스 삭제에 실패했습니다.'));
     } finally {
       setWsDeleting(false);
     }
@@ -217,7 +217,7 @@ export const WsGeneralTab = () => {
       setShowWsLeaveModal(false);
       setActiveTab('profile');
     } catch (err: any) {
-      setWsLeaveError(extractErrorDetail(err, '워크스페이스 나가기에 실패했습니다.'));
+      setWsLeaveError(parseApiError(err, '워크스페이스 나가기에 실패했습니다.'));
     } finally {
       setWsLeaving(false);
     }

--- a/src/features/user/settings/WsMembersTab.tsx
+++ b/src/features/user/settings/WsMembersTab.tsx
@@ -6,7 +6,7 @@ import { getWorkspaceMembers, getMyMembership, inviteMember, updateMemberRole, r
 import type { WorkspaceMemberResponse, WorkspaceMemberPageResponse } from '@/api/workspace';
 
 type MemberItem = WorkspaceMemberPageResponse['content'][number];
-import { extractErrorDetail } from './utils';
+import { parseApiError } from '@/utils/error';
 import { UserPlus, AlertTriangle, MoreHorizontal, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useT } from '@/i18n';
 
@@ -79,7 +79,7 @@ export const WsMembersTab = () => {
       await loadMembers(currentPage);
       setTimeout(() => { setShowInviteModal(false); setInviteSuccess(false); }, 1200);
     } catch (err: any) {
-      setInviteError(extractErrorDetail(err, '초대에 실패했습니다.'));
+      setInviteError(parseApiError(err, '초대에 실패했습니다.'));
     } finally {
       setInviting(false);
     }
@@ -101,7 +101,7 @@ export const WsMembersTab = () => {
       setShowRoleChangeModal(false);
       await loadMembers(currentPage);
     } catch (err: any) {
-      setRoleChangeError(extractErrorDetail(err, '역할 변경에 실패했습니다.'));
+      setRoleChangeError(parseApiError(err, '역할 변경에 실패했습니다.'));
     } finally {
       setRoleChangeLoading(false);
     }
@@ -122,7 +122,7 @@ export const WsMembersTab = () => {
       setShowRemoveMemberModal(false);
       await loadMembers(currentPage);
     } catch (err: any) {
-      setRemoveMemberError(extractErrorDetail(err, '멤버 제거에 실패했습니다.'));
+      setRemoveMemberError(parseApiError(err, '멤버 제거에 실패했습니다.'));
     } finally {
       setRemovingLoading(false);
     }

--- a/src/features/user/settings/utils.ts
+++ b/src/features/user/settings/utils.ts
@@ -1,11 +1,2 @@
-/** authFetch 에러에서 detail 메시지를 추출한다 (CLAUDE.md 규칙) */
-export const extractErrorDetail = (err: any, fallback: string): string => {
-  const msg = err?.message || '';
-  const jsonMatch = msg.match(/\{[\s\S]*\}/);
-  if (jsonMatch) {
-    try {
-      return JSON.parse(jsonMatch[0]).detail || fallback;
-    } catch { /* ignore */ }
-  }
-  return fallback;
-};
+/** @deprecated `@/utils/error`의 `parseApiError`를 사용하세요 */
+export { parseApiError as extractErrorDetail } from '@/utils/error';

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,68 @@
+import { useSetRecoilState } from 'recoil';
+import { useNavigate } from 'react-router-dom';
+import { userState, workspacesState, currentWorkspaceState, GUEST_USER, UserState } from '@/store/atoms';
+import { logoutApi } from '@/api/auth';
+import { getMe } from '@/api/user';
+
+/**
+ * 인증 관련 공통 로직을 제공하는 훅.
+ *
+ * - setAuthUser: 토큰으로 유저 정보를 조회하고 Recoil에 저장 (localStorage는 atom effect가 자동 처리)
+ * - logout: API 로그아웃 + Recoil 초기화 + /login 이동
+ */
+export function useAuth() {
+  const setUser = useSetRecoilState(userState);
+  const setWorkspaces = useSetRecoilState(workspacesState);
+  const setCurrentWsId = useSetRecoilState(currentWorkspaceState);
+  const navigate = useNavigate();
+
+  /**
+   * 토큰을 받아 getMe()로 유저 정보를 조회하고 Recoil userState에 저장한다.
+   * authFetch가 localStorage의 auth.accessToken을 참조하므로,
+   * 호출 전에 localStorage에 토큰이 저장되어 있어야 한다.
+   *
+   * ※ 주의: localStorage에 임시 토큰 저장은 호출측에서 해야 한다.
+   *   (authFetch → getAccessToken → localStorage.getItem('auth') 경로 때문)
+   */
+  const setAuthUser = async (accessToken: string, refreshToken: string): Promise<UserState> => {
+    // authFetch가 토큰을 localStorage에서 읽으므로 임시 저장
+    localStorage.setItem('auth', JSON.stringify({ accessToken, refreshToken }));
+
+    const me = await getMe();
+
+    const userData: UserState = {
+      isLoggedIn: true,
+      id: me.id,
+      name: me.name,
+      email: me.email,
+      avatar: me.name,
+      profileImageUrl: me.profileImageUrl ?? '',
+      baekjoonId: me.baekjoonId ?? '',
+      provider: me.provider,
+      accessToken,
+      refreshToken,
+    };
+
+    // Recoil 업데이트 → authStorageEffect가 자동으로 localStorage 동기화
+    setWorkspaces([]);
+    setUser(userData);
+
+    return userData;
+  };
+
+  const logout = async (refreshToken?: string) => {
+    try {
+      if (refreshToken) {
+        await logoutApi(refreshToken);
+      }
+    } catch {
+      // logout API 실패해도 로컬 상태는 초기화
+    }
+    setUser(GUEST_USER);
+    setWorkspaces([]);
+    setCurrentWsId(0);
+    navigate('/login');
+  };
+
+  return { setAuthUser, logout };
+}

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -125,13 +125,22 @@ export interface UserState {
   provider: string;
 }
 
-function loadUser(): UserState {
+export const GUEST_USER: UserState = {
+  isLoggedIn: false, id: 0, name: 'Guest', email: '', avatar: '',
+  profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '',
+};
+
+/**
+ * userState용 localStorage effect.
+ * 일반 localStorageEffect와 달리 auth 전용 직렬화/역직렬화 로직 포함.
+ */
+const authStorageEffect: AtomEffect<UserState> = ({ setSelf, onSet }) => {
   try {
     const stored = localStorage.getItem('auth');
     if (stored) {
       const parsed = JSON.parse(stored);
       if (parsed && typeof parsed === 'object' && parsed.accessToken) {
-        return {
+        setSelf({
           isLoggedIn: true,
           id: parsed.id || 0,
           name: parsed.name || 'User',
@@ -142,19 +151,29 @@ function loadUser(): UserState {
           provider: parsed.provider || '',
           accessToken: parsed.accessToken as string,
           refreshToken: parsed.refreshToken as string,
-        };
+        });
       }
     }
   } catch (e) {
     console.warn('Failed to load user session, clearing storage:', e);
     localStorage.removeItem('auth');
   }
-  return { isLoggedIn: false, id: 0, name: 'Guest', email: '', avatar: '', profileImageUrl: '', baekjoonId: '', provider: '', accessToken: '', refreshToken: '' };
-}
+
+  onSet((newValue, _, isReset) => {
+    try {
+      if (isReset || !newValue.isLoggedIn) {
+        localStorage.removeItem('auth');
+      } else {
+        localStorage.setItem('auth', JSON.stringify(newValue));
+      }
+    } catch { /* ignore */ }
+  });
+};
 
 export const userState = atom<UserState>({
   key: 'userState',
-  default: loadUser(),
+  default: GUEST_USER,
+  effects: [authStorageEffect],
 });
 
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,16 @@
+/**
+ * authFetch 에러에서 백엔드 detail 메시지를 추출한다 (CLAUDE.md 규칙).
+ *
+ * authFetch는 `throw new Error(`Request failed: ${status} ${body}`)` 형태로 throw하므로
+ * message 안에 포함된 JSON에서 detail 필드를 파싱한다.
+ */
+export function parseApiError(err: unknown, fallback = '요청에 실패했습니다.'): string {
+  const msg = (err as any)?.message || '';
+  const jsonMatch = msg.match(/\{[\s\S]*\}/);
+  if (jsonMatch) {
+    try {
+      return JSON.parse(jsonMatch[0]).detail || fallback;
+    } catch { /* ignore */ }
+  }
+  return fallback;
+}


### PR DESCRIPTION
- userState에 Recoil AtomEffect를 적용하여 localStorage 동기화 자동화
- 인증 로직(로그인/로그아웃)을 useAuth 훅으로 통합하여 중복 제거
- parseApiError 유틸 추출로 에러 처리 일원화 (CLAUDE.md 규칙 준수)