### PR TITLE
fix : resolve time zone rendering

### DIFF
--- a/src/features/community/Community.tsx
+++ b/src/features/community/Community.tsx
@@ -91,7 +91,7 @@ export const Community = () => {
   };
 
   const formatDate = (iso: string) => {
-    const d = new Date(iso);
+    const d = new Date(iso.endsWith('Z') ? iso : iso + 'Z');
     return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
   };
 

--- a/src/features/community/PostDetail.tsx
+++ b/src/features/community/PostDetail.tsx
@@ -166,7 +166,7 @@ export const PostDetail = () => {
   };
 
   const formatDate = (iso: string) => {
-    const d = new Date(iso);
+    const d = new Date(iso.endsWith('Z') ? iso : iso + 'Z');
     return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
   };
 

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -11,7 +11,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 function formatDeadline(deadline: string) {
-  const d = new Date(deadline);
+  const d = new Date(deadline.endsWith('Z') ? deadline : deadline + 'Z');
   const now = new Date();
   const diffMs = d.getTime() - now.getTime();
   const diffH = Math.floor(diffMs / (1000 * 60 * 60));
@@ -22,7 +22,7 @@ function formatDeadline(deadline: string) {
 }
 
 function formatDate(isoStr: string) {
-  const d = new Date(isoStr);
+  const d = new Date(isoStr.endsWith('Z') ? isoStr : isoStr + 'Z');
   return `${d.getFullYear()}. ${d.getMonth() + 1}. ${d.getDate()}.`;
 }
 

--- a/src/features/problems/ProblemList.tsx
+++ b/src/features/problems/ProblemList.tsx
@@ -24,7 +24,7 @@ type MemberRole = 'OWNER' | 'ADMIN' | 'MANAGER' | 'MEMBER';
 
 function relativeTime(dateStr: string, t: (key: string, vars?: Record<string, string | number>) => string): string {
   const now = Date.now();
-  const then = new Date(dateStr).getTime();
+  const then = new Date(dateStr.endsWith('Z') ? dateStr : dateStr + 'Z').getTime();
   const diff = now - then;
 
   const seconds = Math.floor(diff / 1000);
@@ -664,7 +664,7 @@ export const ProblemList = () => {
                           )}
                         </div>
                         <div className="text-text-muted text-xs">
-                          {p.deadline ? new Date(p.deadline).toLocaleDateString(lang === 'ko' ? 'ko-KR' : 'en-US') : '-'}
+                          {p.deadline ? new Date(p.deadline.endsWith('Z') ? p.deadline : p.deadline + 'Z').toLocaleDateString(lang === 'ko' ? 'ko-KR' : 'en-US') : '-'}
                         </div>
                         {/* 액션 메뉴 */}
                         <div className="text-center">

--- a/src/features/problems/ProblemSolutions.tsx
+++ b/src/features/problems/ProblemSolutions.tsx
@@ -314,7 +314,7 @@ export const ProblemSolutions = () => {
                       <span className={isActive ? 'text-emerald-500' : ''}>{sol.memberName}</span>
                     </div>
                     <span className="text-[10px] text-text-faint">
-                      {new Date(sol.updatedAt).toLocaleString('ko-KR', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                      {new Date(sol.updatedAt.endsWith('Z') ? sol.updatedAt : sol.updatedAt + 'Z').toLocaleString('ko-KR', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                     </span>
                   </div>
 
@@ -354,7 +354,7 @@ export const ProblemSolutions = () => {
                   </span>
                   <span className="flex items-center gap-1">
                     <Calendar className="w-3 h-3" />
-                    {new Date(activeSolution.updatedAt).toLocaleString('ko-KR', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                    {new Date(activeSolution.updatedAt.endsWith('Z') ? activeSolution.updatedAt : activeSolution.updatedAt + 'Z').toLocaleString('ko-KR', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                   </span>
                   <StatusBadge status={activeSolution.latestStatus} />
                 </div>
@@ -388,7 +388,7 @@ export const ProblemSolutions = () => {
                 <span className="font-medium text-text-secondary">제출 기록 (Version {displayVersionNum} / {totalVersions})</span>
                 {activeVersion && (
                   <span className="text-text-faint">
-                    {new Date(activeVersion.createdAt).toLocaleString('ko-KR', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                    {new Date(activeVersion.createdAt.endsWith('Z') ? activeVersion.createdAt : activeVersion.createdAt + 'Z').toLocaleString('ko-KR', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                   </span>
                 )}
                 {activeVersion && <StatusBadge status={activeVersion.status} />}
@@ -489,7 +489,7 @@ export const ProblemSolutions = () => {
                   <div className="text-text-muted flex-1">{c.content}</div>
                   <div className="flex items-center gap-2 shrink-0">
                     <span className="text-text-faint text-xs">
-                      {new Date(c.createdAt).toLocaleString('ko-KR', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                      {new Date(c.createdAt.endsWith('Z') ? c.createdAt : c.createdAt + 'Z').toLocaleString('ko-KR', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                     </span>
                     {c.isMyComment && (
                       <button


### PR DESCRIPTION
time zone이 front에서 9시간 전으로 표시되던 문제 해결

- db에는 애초에 UTC 기준의 날짜 및 시간으로 저장됨
- front에서 해당 시간이 UTC 기준의 시간이라는 정보인 'Z'가 누락됐으므로 명시적으로 추가하여 해결