### PR TITLE
fix: 문제 정답 제출 시 대시보드/마이페이지 자동 갱신

### DIFF
--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { workspacesState, currentWorkspaceState, isCreateWorkspaceModalOpenState } from '@/store/atoms';
 import { useWorkspaceNavigate } from '@/hooks/useWorkspaceNavigate';
@@ -73,7 +73,7 @@ export const Dashboard = () => {
 
   const currentWorkspace = workspaces.find(w => w.id === currentWorkspaceId);
 
-  useEffect(() => {
+  const fetchDashboard = useCallback(() => {
     if (!currentWorkspaceId) return;
     setLoading(true);
     getWorkspaceDashboard(currentWorkspaceId)
@@ -81,6 +81,15 @@ export const Dashboard = () => {
       .catch(err => console.error('Failed to load dashboard:', err))
       .finally(() => setLoading(false));
   }, [currentWorkspaceId]);
+
+  useEffect(() => {
+    fetchDashboard();
+  }, [fetchDashboard]);
+
+  useEffect(() => {
+    window.addEventListener('ujaxProblemAccepted', fetchDashboard);
+    return () => window.removeEventListener('ujaxProblemAccepted', fetchDashboard);
+  }, [fetchDashboard]);
 
   if (!currentWorkspace) {
     return (

--- a/src/features/ide/hooks/useSubmitLogic.ts
+++ b/src/features/ide/hooks/useSubmitLogic.ts
@@ -21,6 +21,7 @@ export function useSubmitLogic(problem: ProblemResponse | null) {
       if (isAccepted) {
         setSubmitStatus('accepted');
         setSubmitResult('맞았습니다!!');
+        window.dispatchEvent(new CustomEvent('ujaxProblemAccepted'));
       } else {
         setSubmitStatus('wrong');
         setSubmitResult(verdict);

--- a/src/features/user/Profile.tsx
+++ b/src/features/user/Profile.tsx
@@ -210,11 +210,20 @@ export const Profile = () => {
   const [profileData, setProfileData] = useState<WorkspaceMemberProfileResponse | null>(null);
   const [activityData, setActivityData] = useState<WorkspaceMemberProfileActivityResponse | null>(null);
 
-  useEffect(() => {
+  const fetchProfile = useCallback(() => {
     if (!currentWsId) return;
     getMyWorkspaceProfile(currentWsId).then(setProfileData).catch(() => {});
     getMyWorkspaceProfileActivity(currentWsId).then(setActivityData).catch(() => {});
   }, [currentWsId]);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  useEffect(() => {
+    window.addEventListener('ujaxProblemAccepted', fetchProfile);
+    return () => window.removeEventListener('ujaxProblemAccepted', fetchProfile);
+  }, [fetchProfile]);
 
   const handleYearChange = useCallback((year: number | null) => {
     if (!currentWsId) return;


### PR DESCRIPTION
# summary

- 맞았습니다 결과 수신 시 ujaxProblemAccepted 이벤트를 dispatch하여 Dashboard와 Profile이 새로고침 없이 즉시 데이터를 재조회하도록 수정