### PR TITLE
fix: stabilize submit flow and profile bojId validation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -280,16 +280,18 @@ function AppContent() {
   const setMyWorkspaceRole = useRecoilState(myWorkspaceRoleState)[1];
   const location = useLocation();
   const navigate = useNavigate();
+  const normalizeBojId = (value?: string | null) => String(value ?? '').trim();
 
   // 앱 시작 시 로그인 상태면 서버에서 최신 유저 정보 동기화 (profileImageUrl 등 stale 방지)
   React.useEffect(() => {
     if (!user.isLoggedIn) return;
     getMe().then(me => {
+      const normalizedBojId = normalizeBojId(me.baekjoonId);
       setUser(prev => prev.isLoggedIn ? {
         ...prev,
         name: me.name,
         profileImageUrl: me.profileImageUrl ?? '',
-        baekjoonId: me.baekjoonId ?? '',
+        baekjoonId: normalizedBojId,
       } : prev);
     }).catch(() => { /* 실패 시 기존 캐시 유지 */ });
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -330,6 +332,17 @@ function AppContent() {
       window.removeEventListener('ujaxAuthExpired', onAuthExpired);
     };
   }, [navigate, setUser, setWorkspaces, setCurrentWsId, setCurrentProblemBox, setMyWorkspaceRole]);
+
+  // 같은 탭에서 프로필(baekjoonId) 변경 시에도 extension으로 즉시 동기화
+  React.useEffect(() => {
+    if (!user.isLoggedIn || !user.accessToken) return;
+    const normalizedBojId = normalizeBojId(user.baekjoonId);
+    window.postMessage({
+      type: 'ujaxAuthChanged',
+      token: user.accessToken,
+      bojId: normalizedBojId || null,
+    }, '*');
+  }, [user.isLoggedIn, user.accessToken, user.baekjoonId]);
 
   // 사이드바를 숨겨야 하는 페이지: 인증, IDE, 홈, 풀이 보기(solutions)
   const isFullScreen = ['/login', '/signup', '/signup/terms', '/signup/verify', '/oauth/callback', '/'].includes(location.pathname)

--- a/src/features/ide/IDE.tsx
+++ b/src/features/ide/IDE.tsx
@@ -5,7 +5,7 @@ import Editor from '@monaco-editor/react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { useParams } from 'react-router-dom';
 import { useWorkspaceNavigate } from '@/hooks/useWorkspaceNavigate';
-import { ideCodeState, ideLanguageState, currentWorkspaceState, problemContextState } from '@/store/atoms';
+import { ideCodeState, ideLanguageState, currentWorkspaceState, problemContextState, userState } from '@/store/atoms';
 import type { IdeTestResult } from '@/store/atoms';
 import { getProblemByNumber } from '@/api/problem';
 import type { ProblemResponse } from '@/api/problem';
@@ -188,6 +188,7 @@ export const IDE = () => {
   const [code, setCode] = useRecoilState(ideCodeState);
   const [language, setLanguage] = useRecoilState(ideLanguageState);
   const currentWsId = useRecoilValue(currentWorkspaceState);
+  const user = useRecoilValue(userState);
   const problemCtxMap = useRecoilValue(problemContextState);
   const { toWs } = useWorkspaceNavigate();
   const { problemId } = useParams();
@@ -760,8 +761,8 @@ export const IDE = () => {
           </Button>
           <Button
             className="text-white text-sm px-5 py-2 font-semibold bg-emerald-600 hover:bg-emerald-700"
-            onClick={() => handleSubmit(code, language)}
-            disabled={!problem || submitStatus === 'submitted'}
+            onClick={() => handleSubmit(code, language, user.baekjoonId)}
+            disabled={!problem || submitStatus === 'submitted' || !user.baekjoonId?.trim()}
           >
             제출
           </Button>

--- a/src/features/ide/IDESubmitModal.tsx
+++ b/src/features/ide/IDESubmitModal.tsx
@@ -18,6 +18,9 @@ export function IDESubmitModal({ show, status, result, problemNumber, onClose }:
   const problemLabel = problemNumber ? `${problemNumber}번 문제` : '';
 
   const isJudging = status === 'submitted';
+  const wrongMessage = result || '다시 시도해주세요.';
+  const isJudgeWrongVerdict = /(틀렸|wrong|오답|time limit|runtime|compile|메모리|시간 초과|런타임|컴파일)/i.test(wrongMessage);
+  const wrongTitle = isJudgeWrongVerdict ? '틀렸습니다' : '제출 확인 실패';
 
   return (
     <div
@@ -58,7 +61,8 @@ export function IDESubmitModal({ show, status, result, problemNumber, onClose }:
           <>
             <AlertCircle className="w-16 h-16 text-red-500" />
             <p className="text-base font-semibold text-text-secondary">{problemLabel}</p>
-            <p className="text-2xl font-bold text-red-500">{result || '틀렸습니다'}</p>
+            <p className="text-2xl font-bold text-red-500">{wrongTitle}</p>
+            <p className="mt-0.5 px-8 text-center text-sm leading-relaxed text-text-secondary">{wrongMessage}</p>
             <Button variant="primary" onClick={onClose} className="mt-2 text-sm px-6 py-2">확인</Button>
           </>
         )}

--- a/src/features/ide/hooks/useSubmitLogic.ts
+++ b/src/features/ide/hooks/useSubmitLogic.ts
@@ -2,6 +2,65 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import type { ProblemResponse } from '@/api/problem';
 import type { SubmitStatus } from '@/features/ide/IDESubmitModal';
 
+const REASON_MESSAGE_MAP: Record<string, string> = {
+  MISSING_BOJ_ID: '프로필에 백준 아이디를 먼저 입력해주세요.',
+  BOJ_ID_MISMATCH: 'BOJ 로그인 계정과 프로필 아이디가 달라요. 같은 계정으로 맞춘 뒤 다시 시도해주세요.',
+  CONTEXT_DELAY: '문제 연결 준비가 조금 늦어지고 있어요. 잠시 후 다시 시도해주세요.',
+  SUBMISSION_NOT_FOUND: '제출 내역을 아직 찾지 못했어요. 잠시 후 다시 시도해주세요.',
+  SUBMIT_FLOW_BUSY: '이전 제출을 처리 중이에요. 잠시 후 다시 시도해주세요.',
+  SUBMIT_REQUEST_INVALID: '제출 요청 정보가 올바르지 않아요. 코드를 확인한 뒤 다시 시도해주세요.',
+  UNSUPPORTED_LANGUAGE: '현재 선택한 언어는 자동 제출을 지원하지 않아요.',
+  SUBMIT_FLOW_ERROR: '제출 처리 중 오류가 발생했어요. 잠시 후 다시 시도해주세요.',
+  STATUS_USERNAME_MISSING: '백준 사용자 정보를 읽지 못했어요. 잠시 후 다시 시도해주세요.',
+  PROBLEM_MISMATCH: '현재 문제와 다른 제출이 감지됐어요. 다시 제출해주세요.',
+  AUTH_REQUIRED: '로그인 상태를 확인한 뒤 다시 시도해주세요.',
+  BACKEND_RETRY_FAILED: '제출 결과 동기화 재시도에 실패했어요. 잠시 후 다시 시도해주세요.',
+  SUBMISSION_INGEST_FAILED: '제출 결과 동기화에 실패했어요. 잠시 후 다시 시도해주세요.',
+  NETWORK_ERROR: '네트워크 오류로 제출 결과를 동기화하지 못했어요. 잠시 후 다시 시도해주세요.',
+};
+
+function normalizeExtensionVerdict(verdict: string) {
+  return String(verdict || '')
+    .replace(/\[UJAX\]\s*/g, '')
+    .replace(/^제출 확인 실패:\s*/g, '')
+    .trim();
+}
+
+function extractBojMismatchMessage(verdict: string) {
+  const cleaned = normalizeExtensionVerdict(verdict);
+  const match = cleaned.match(/BOJ 로그인 계정\(([^)]+)\)과 설정 아이디\(([^)]+)\)가 다릅니다\.?/);
+  if (!match) return '';
+  return `BOJ 로그인 계정(${match[1]})과 설정 아이디(${match[2]})가 다릅니다.`;
+}
+
+function getSubmitErrorMessage(reasonCode: string, verdict: string) {
+  const mismatchMessage = extractBojMismatchMessage(verdict);
+  if (mismatchMessage) return mismatchMessage;
+
+  if (reasonCode && REASON_MESSAGE_MAP[reasonCode]) {
+    return REASON_MESSAGE_MAP[reasonCode];
+  }
+
+  const cleanedVerdict = normalizeExtensionVerdict(verdict);
+  if (cleanedVerdict.includes('로그인 계정') && cleanedVerdict.includes('설정 아이디')) {
+    return REASON_MESSAGE_MAP.BOJ_ID_MISMATCH;
+  }
+  if (cleanedVerdict.includes('백준 아이디')) {
+    return REASON_MESSAGE_MAP.MISSING_BOJ_ID;
+  }
+  if (cleanedVerdict.includes('컨텍스트')) {
+    return REASON_MESSAGE_MAP.CONTEXT_DELAY;
+  }
+  if (cleanedVerdict.includes('이전 제출 처리 중')) {
+    return REASON_MESSAGE_MAP.SUBMIT_FLOW_BUSY;
+  }
+  if (cleanedVerdict.includes('제출 내역') || cleanedVerdict.includes('찾지 못')) {
+    return REASON_MESSAGE_MAP.SUBMISSION_NOT_FOUND;
+  }
+
+  return cleanedVerdict || '제출 처리 중 오류가 발생했어요.';
+}
+
 export function useSubmitLogic(problem: ProblemResponse | null) {
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>('idle');
   const [submitResult, setSubmitResult] = useState<string | null>(null);
@@ -15,6 +74,18 @@ export function useSubmitLogic(problem: ProblemResponse | null) {
       if (!problem || String(event.data.problemNum) !== String(problem.problemNumber)) return;
 
       const verdict = event.data.verdict || '';
+      const reasonCode = String(event.data.reasonCode || '').trim();
+
+      if (reasonCode) {
+        setSubmitStatus('wrong');
+        setSubmitResult(getSubmitErrorMessage(reasonCode, verdict));
+        if (submitTimeoutRef.current) {
+          clearTimeout(submitTimeoutRef.current);
+          submitTimeoutRef.current = null;
+        }
+        return;
+      }
+
       const ACCEPTED_KEYWORDS = ['맞았습니다', 'Accepted'];
       const isAccepted = ACCEPTED_KEYWORDS.some((kw) => verdict.includes(kw));
 
@@ -23,8 +94,9 @@ export function useSubmitLogic(problem: ProblemResponse | null) {
         setSubmitResult('맞았습니다!!');
         window.dispatchEvent(new CustomEvent('ujaxProblemAccepted'));
       } else {
+        const normalizedMessage = getSubmitErrorMessage('', verdict);
         setSubmitStatus('wrong');
-        setSubmitResult(verdict);
+        setSubmitResult(normalizedMessage);
       }
 
       if (submitTimeoutRef.current) {
@@ -43,14 +115,26 @@ export function useSubmitLogic(problem: ProblemResponse | null) {
     };
   }, []);
 
-  const handleSubmit = useCallback((code: string, language: string) => {
+  const handleSubmit = useCallback((code: string, language: string, expectedBojId?: string | null) => {
     if (!problem) return;
+    const normalizedBojId = String(expectedBojId || '').trim();
+    if (!normalizedBojId) {
+      if (submitTimeoutRef.current) {
+        clearTimeout(submitTimeoutRef.current);
+        submitTimeoutRef.current = null;
+      }
+      setSubmitStatus('wrong');
+      setSubmitResult('백준 아이디가 설정되지 않았습니다. 설정 > 프로필에서 백준 아이디를 먼저 등록해주세요.');
+      setShowSubmitModal(true);
+      return;
+    }
 
     window.postMessage({
       type: 'ujaxSubmitRequest',
       problemNum: problem.problemNumber,
       code,
       language,
+      expectedBojId: normalizedBojId,
     }, '*');
 
     setSubmitStatus('submitted');
@@ -64,6 +148,10 @@ export function useSubmitLogic(problem: ProblemResponse | null) {
   }, [problem]);
 
   const closeSubmitModal = useCallback(() => {
+    if (submitTimeoutRef.current) {
+      clearTimeout(submitTimeoutRef.current);
+      submitTimeoutRef.current = null;
+    }
     setShowSubmitModal(false);
     setSubmitStatus('idle');
     setSubmitResult(null);

--- a/src/features/problems/ProblemRegistration.tsx
+++ b/src/features/problems/ProblemRegistration.tsx
@@ -38,13 +38,18 @@ export const ProblemRegistration = () => {
       resetCrawl();
       (async () => {
         const num = parseInt(problemNumber, 10);
-        const data = await findProblemByNumber(num);
-        if (data) {
-          setProblem(data);
-          setFlowStatus('found');
-        } else {
+        try {
+          const data = await findProblemByNumber(num);
+          if (data) {
+            setProblem(data);
+            setFlowStatus('found');
+            return;
+          }
           setFlowStatus('error');
           setErrorMsg('크롤링은 완료되었으나 문제 데이터를 찾을 수 없습니다.');
+        } catch (err: any) {
+          setFlowStatus('error');
+          setErrorMsg(parseApiError(err, '문제 조회 중 오류가 발생했습니다.'));
         }
       })();
     } else if (crawlStatus === 'error') {
@@ -59,10 +64,9 @@ export const ProblemRegistration = () => {
       resetCrawl();
     } else if (crawlStatus === 'timeout') {
       setFlowStatus('timeout');
-      setErrorMsg('확장 프로그램이 설치되어 있는지 확인해주세요.');
-      resetCrawl();
+      setErrorMsg('연결이 지연되고 있습니다. 잠시 후 자동 반영될 수 있으며, 계속 실패하면 새로고침 후 다시 시도해주세요.');
     }
-  }, [crawlStatus]);
+  }, [crawlStatus, crawlReason, problemNumber, resetCrawl]);
 
   // 문제 번호로 조회 (미리보기)
   const handleLookup = async () => {

--- a/src/features/user/Settings.tsx
+++ b/src/features/user/Settings.tsx
@@ -24,15 +24,17 @@ export const Settings = () => {
   const workspaces = useRecoilValue(workspacesState);
   const [user, setUser] = useRecoilState(userState);
   const t = useT();
+  const normalizeBojId = (value?: string | null) => String(value ?? '').trim();
 
   // 설정 진입 시 최신 프로필 데이터로 Recoil 동기화 (localStorage는 atom effect가 자동 처리)
   useEffect(() => {
     getMe().then(data => {
+      const normalizedBojId = normalizeBojId(data.baekjoonId);
       setUser(prev => ({
         ...prev,
         name: data.name,
         profileImageUrl: data.profileImageUrl ?? '',
-        baekjoonId: data.baekjoonId ?? '',
+        baekjoonId: normalizedBojId,
       }));
     }).catch(() => { /* ignore - ProfileTab will also fetch */ });
   }, [setUser]);

--- a/src/features/user/settings/ProfileTab.tsx
+++ b/src/features/user/settings/ProfileTab.tsx
@@ -35,16 +35,18 @@ export const ProfileTab = () => {
   const [deleteConfirmEmail, setDeleteConfirmEmail] = useState('');
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState('');
+  const normalizeBojId = (value?: string | null) => String(value ?? '').trim();
 
   // Load user profile on mount
   useEffect(() => {
     getMe().then(data => {
+      const normalizedBojId = normalizeBojId(data.baekjoonId);
       setName(data.name);
       setEmail(data.email);
       setProfileImageUrl(data.profileImageUrl ?? '');
-      setBaekjoonId(data.baekjoonId ?? '');
+      setBaekjoonId(normalizedBojId);
       setOriginalName(data.name);
-      setOriginalBaekjoonId(data.baekjoonId ?? '');
+      setOriginalBaekjoonId(normalizedBojId);
       setOriginalImageUrl(data.profileImageUrl ?? '');
       // Recoil 업데이트 → authStorageEffect가 localStorage 자동 동기화
       setUser(prev => ({
@@ -53,7 +55,7 @@ export const ProfileTab = () => {
         name: data.name,
         email: data.email,
         profileImageUrl: data.profileImageUrl ?? '',
-        baekjoonId: data.baekjoonId ?? '',
+        baekjoonId: normalizedBojId,
         provider: data.provider,
       }));
     }).catch(err => {
@@ -101,10 +103,22 @@ export const ProfileTab = () => {
     setSaveResult(null);
     setSaveError('');
     try {
+      const normalizedBaekjoonId = baekjoonId.trim();
+      const normalizedOriginalBaekjoonId = originalBaekjoonId.trim();
+
+      // 공백-only 입력은 프론트에서 즉시 차단
+      if (baekjoonId.length > 0 && !normalizedBaekjoonId) {
+        setSaveResult('error');
+        setSaveError(t('settings.profile.baekjoonWhitespaceError'));
+        return;
+      }
+
       // 변경된 필드만 전송
       const requestBody: Record<string, string | null> = {};
       if (name !== originalName) requestBody.name = name;
-      if (baekjoonId !== originalBaekjoonId) requestBody.baekjoonId = baekjoonId || null;
+      if (normalizedBaekjoonId !== normalizedOriginalBaekjoonId) {
+        requestBody.baekjoonId = normalizedBaekjoonId || null;
+      }
 
       if (imageRemoved) {
         requestBody.profileImageUrl = null;
@@ -129,20 +143,22 @@ export const ProfileTab = () => {
 
       const updated = await updateMe(requestBody);
       // Recoil 업데이트 → authStorageEffect가 localStorage 자동 동기화
+      const updatedBojId = normalizeBojId(updated.baekjoonId);
       setUser(prev => ({
         ...prev,
         name: updated.name,
         profileImageUrl: updated.profileImageUrl ?? '',
-        baekjoonId: updated.baekjoonId ?? '',
+        baekjoonId: updatedBojId,
       }));
       setProfileImageUrl(updated.profileImageUrl ?? '');
+      setBaekjoonId(updatedBojId);
       setPreviewUrl('');
       setPendingFile(null);
       setImageRemoved(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
       // 원본값 갱신
       setOriginalName(updated.name);
-      setOriginalBaekjoonId(updated.baekjoonId ?? '');
+      setOriginalBaekjoonId(updatedBojId);
       setOriginalImageUrl(updated.profileImageUrl ?? '');
       setSaveResult('success');
     } catch (err: any) {
@@ -216,7 +232,14 @@ export const ProfileTab = () => {
         <h3 className="text-sm font-bold text-text-secondary">{t('settings.profile.linkedAccounts')}</h3>
         <div>
           <label className="block text-xs font-bold text-text-faint mb-1">{t('settings.profile.baekjoonId')}</label>
-          <input type="text" value={baekjoonId} onChange={e => setBaekjoonId(e.target.value)} placeholder={t('settings.profile.baekjoonPlaceholder')} className="w-full bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm text-text-secondary focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none" />
+          <input
+            type="text"
+            value={baekjoonId}
+            onChange={e => setBaekjoonId(e.target.value)}
+            onBlur={() => setBaekjoonId(prev => prev.trim())}
+            placeholder={t('settings.profile.baekjoonPlaceholder')}
+            className="w-full bg-input-bg border border-border-subtle rounded px-3 py-1.5 text-sm text-text-secondary focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+          />
           <p className="text-[11px] text-text-faint mt-1">{t('settings.profile.baekjoonDesc')}</p>
         </div>
         <div className="space-y-2 pt-2">

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -20,6 +20,8 @@ export function useAuth() {
   const setProblemContext = useSetRecoilState(problemContextState);
   const navigate = useNavigate();
 
+  const normalizeBojId = (value?: string | null) => String(value ?? '').trim();
+
   /**
    * 토큰을 받아 getMe()로 유저 정보를 조회하고 Recoil userState에 저장한다.
    * authFetch가 localStorage의 auth.accessToken을 참조하므로,
@@ -40,6 +42,8 @@ export function useAuth() {
       throw e;
     }
 
+    const normalizedBojId = normalizeBojId(me.baekjoonId);
+
     const userData: UserState = {
       isLoggedIn: true,
       id: me.id,
@@ -47,7 +51,7 @@ export function useAuth() {
       email: me.email,
       avatar: me.name,
       profileImageUrl: me.profileImageUrl ?? '',
-      baekjoonId: me.baekjoonId ?? '',
+      baekjoonId: normalizedBojId,
       provider: me.provider,
       accessToken,
       refreshToken,
@@ -56,6 +60,7 @@ export function useAuth() {
     // Recoil 업데이트 → authStorageEffect가 자동으로 localStorage 동기화
     setWorkspaces([]);
     setUser(userData);
+    window.postMessage({ type: 'ujaxAuthChanged', token: accessToken, bojId: normalizedBojId || null }, '*');
 
     return userData;
   };
@@ -83,6 +88,7 @@ export function useAuth() {
     setCurrentProblemBox(null);
     setMyWorkspaceRole('MEMBER');
     setProblemContext({});
+    window.postMessage({ type: 'ujaxAuthChanged', token: null, bojId: null }, '*');
     navigate('/login');
   };
 

--- a/src/hooks/useExtensionCrawl.ts
+++ b/src/hooks/useExtensionCrawl.ts
@@ -3,7 +3,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 type CrawlStatus = 'idle' | 'crawling' | 'success' | 'error' | 'timeout';
 export type CrawlReason = 'NOT_FOUND' | 'SERVER_ERROR' | 'NETWORK_ERROR' | null;
 
-const CRAWL_TIMEOUT_MS = 8_000;
+const CRAWL_TIMEOUT_MS = 20_000;
 
 export function useExtensionCrawl() {
   const [status, setStatus] = useState<CrawlStatus>('idle');
@@ -39,6 +39,7 @@ export function useExtensionCrawl() {
   const requestCrawl = useCallback((problemNum: number) => {
     cleanup();
     problemNumRef.current = problemNum;
+    setReason(null);
     setStatus('crawling');
 
     window.postMessage({

--- a/src/hooks/useExtensionProblemContext.ts
+++ b/src/hooks/useExtensionProblemContext.ts
@@ -1,15 +1,30 @@
 import { useEffect, useRef } from 'react';
 
+const CONTEXT_RETRY_DELAYS_MS = [0, 300, 1_200];
+
+function postProblemContext(problemNum: number, workspaceProblemId: number) {
+  window.postMessage(
+    { type: 'ujaxProblemContext', problemNum, workspaceProblemId },
+    '*',
+  );
+}
+
 export function useExtensionProblemContext(
   problemNum: number | null,
   workspaceProblemId: number | null,
 ) {
   useEffect(() => {
     if (!problemNum || !workspaceProblemId) return;
-    window.postMessage(
-      { type: 'ujaxProblemContext', problemNum, workspaceProblemId },
-      '*',
+
+    const timers = CONTEXT_RETRY_DELAYS_MS.map((delay) =>
+      window.setTimeout(() => {
+        postProblemContext(problemNum, workspaceProblemId);
+      }, delay),
     );
+
+    return () => {
+      timers.forEach((timerId) => window.clearTimeout(timerId));
+    };
   }, [problemNum, workspaceProblemId]);
 }
 
@@ -28,11 +43,18 @@ export function useExtensionBatchContext(
     if (key === prevKey.current) return;
     prevKey.current = key;
 
+    const timers: number[] = [];
     problems.forEach(p => {
-      window.postMessage(
-        { type: 'ujaxProblemContext', problemNum: p.problemNumber, workspaceProblemId: p.workspaceProblemId },
-        '*',
-      );
+      CONTEXT_RETRY_DELAYS_MS.forEach((delay) => {
+        const timerId = window.setTimeout(() => {
+          postProblemContext(p.problemNumber, p.workspaceProblemId);
+        }, delay);
+        timers.push(timerId);
+      });
     });
+
+    return () => {
+      timers.forEach((timerId) => window.clearTimeout(timerId));
+    };
   }, [problems]);
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -315,6 +315,7 @@ export const en: Record<string, string> = {
   'settings.profile.baekjoonId': 'Baekjoon ID',
   'settings.profile.baekjoonPlaceholder': 'Enter your Baekjoon ID',
   'settings.profile.baekjoonDesc': 'Used for solved.ac tier integration.',
+  'settings.profile.baekjoonWhitespaceError': 'Baekjoon ID cannot be only whitespace.',
   'settings.profile.fileTypeError': 'Only JPG, PNG, WEBP formats are supported.',
   'settings.profile.fileSizeError': 'File size must be 5MB or less.',
   'settings.profile.dangerZone': 'Danger Zone',

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -315,6 +315,7 @@ export const ko: Record<string, string> = {
   'settings.profile.baekjoonId': '백준 아이디',
   'settings.profile.baekjoonPlaceholder': '백준 아이디를 입력하세요',
   'settings.profile.baekjoonDesc': 'solved.ac 티어 연동에 사용됩니다.',
+  'settings.profile.baekjoonWhitespaceError': '백준 아이디는 공백만 입력할 수 없습니다.',
   'settings.profile.fileTypeError': 'JPG, PNG, WEBP 형식만 지원합니다.',
   'settings.profile.fileSizeError': '파일 크기는 5MB 이하여야 합니다.',
   'settings.profile.dangerZone': '위험 구역',


### PR DESCRIPTION
## 요약
- IDE 제출 플로우와 오류 처리 UX를 안정화
- 프로필/인증/앱 동기화 전 구간에서 `baekjoonId` 처리
- `baekjoonId`가 공백만 입력된 경우 프론트에서 저장되지 않도록 차단

## 변경 사항
- IDE 제출 모달/메시지 처리 개선
  - 제출 결과 메시지를 사용자 친화적으로 정리
  - extension 스타일 접두어(`[UJAX] ...`) 노출을 제거하고, 계정 불일치 문구를 일관된 형태로 표시하도록 보정

- 프로필 저장 검증 강화
  - `baekjoonId` 공백-only 입력을 프론트에서 즉시 차단
  - 저장 요청 시 `trim`된 `baekjoonId`만 전송하도록 수정
  - 저장/조회 후 Recoil 상태도 정규화된 값으로 동기화

- 인증/앱 동기화 안정화
  - `getMe` 응답 반영 및 extension 브리지 메시지 전송 시 `baekjoonId`를 정규화(`trim`)하도록 통일
  - 같은 탭에서 프로필 변경 시 front-extension 간 값 불일치 가능성을 줄임

- 기타 안정화
  - extension 컨텍스트/크롤링 타이밍 관련 훅 동작을 보완

## 검증
- `npx tsc --noEmit` 통과
- `npm run build` 통과
